### PR TITLE
IBM Spectrum Virtualize v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Code of conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html )
 
-This collection provides a series of Ansible modules and plugins for interacting with the IBM Spectrum Virtualize Family storage products. These products include the IBM SAN Volume Controller, IBM FlashSystem Family members built with IBM Spectrum Virtualize (FlashSystem 5000, 5100, 5200, 7200, 9100, 9200, 9200R, and V9000), IBM Storwize Family, and IBM Spectrum Virtualize for Public Cloud. For more information regarding these products, see the [IBM Documentation](https://www.ibm.com/docs/en ).
+This collection provides a series of Ansible modules and plugins for interacting with the IBM Spectrum Virtualize family storage products. These products include the IBM SAN Volume Controller, IBM FlashSystem family members built with IBM Spectrum Virtualize (FlashSystem 5xxx, 7200, 9100, 9200, 9200R, and V9000), IBM Storwize family, and IBM Spectrum Virtualize for Public Cloud. For more information regarding these products, see [IBM Documentation](https://www.ibm.com/docs/en ).
 
 ## Requirements
 
@@ -68,27 +68,40 @@ Alternatively, you can add a full namepsace and collection name in the `collecti
 
 ### Modules
 
-- ibm_svc_auth - Generates an authentication token for a user on IBM Spectrum Virtualize Family storage system
+- ibm_svc_auth - Generates an authentication token for a user on IBM Spectrum Virtualize family storage system
 - ibm_svc_host - Manages hosts on IBM Spectrum Virtualize system
 - ibm_svc_hostcluster - Manages host cluster on IBM Spectrum Virtualize system
 - ibm_svc_info - Collects information on IBM Spectrum Virtualize system
+- ibm_svc_initial_setup - Manages initial setup configuration on IBM Spectrum Virtualize system
+- ibm_svc_manage_callhome - Manages configuration of Call Home feature on IBM Spectrum Virtualize system
 - ibm_svc_manage_consistgrp_flashcopy - Manages FlashCopy consistency groups on IBM Spectrum Virtualize system
 - ibm_svc_manage_cv - Manages the change volume in remote copy replication on IBM Spectrum Virtualize system
 - ibm_svc_manage_flashcopy - Manages FlashCopy mappings on IBM Spectrum Virtualize system
 - ibm_svc_manage_mirrored_volume - Manages mirrored volumes on IBM Spectrum Virtualize system
 - ibm_svc_manage_migration - Manages volume migration between clusters on IBM Spectrum Virtualize system
+- ibm_svc_manage_ownershipgroup - Manages ownership groups on IBM Spectrum Virtualize system
 - ibm_svc_manage_replication - Manages remote copy replication on IBM Spectrum Virtualize system
-- ibm_svc_manage_replicationgroup - Manages remote copy consistency group on IBM Spectrum Virtualize system
+- ibm_svc_manage_replicationgroup - Manages remote copy consistency groups on IBM Spectrum Virtualize system
+- ibm_svc_manage_sra - Manages the remote support assistance configuration on IBM Spectrum Virtualize system
+- ibm_svc_manage_user - Manages user on IBM Spectrum Virtualize system
+- ibm_svc_manage_usergroup - Manages user groups on IBM Spectrum Virtualize system
 - ibm_svc_manage_volume - Manages standard volumes on IBM Spectrum Virtualize system
 - ibm_svc_manage_volumegroup - Manages volume groups on IBM Spectrum Virtualize system
 - ibm_svc_mdisk - Manages MDisks for IBM Spectrum Virtualize system
 - ibm_svc_mdiskgrp - Manages pools for IBM Spectrum Virtualize system
 - ibm_svc_start_stop_flashcopy - Starts or stops FlashCopy mapping and consistency groups on IBM Spectrum Virtualize system
-- ibm_svc_start_stop_replication - Starts or stops remote copy relationship or group on IBM Spectrum Virtualize system
+- ibm_svc_start_stop_replication - Starts or stops remote-copy independent relationships or consistency groups on IBM Spectrum Virtualize system
 - ibm_svc_vol_map - Manages volume mapping for IBM Spectrum Virtualize system
 - ibm_svcinfo_command - Runs svcinfo CLI command on IBM Spectrum Virtualize system over SSH session
 - ibm_svctask_command - Runs svctask CLI command(s) on IBM Spectrum Virtualize system over SSH session
 
+### Other Feature Information
+- SV Ansible Collection v1.7.0 provides `Setup and Configuration Automation` through different modules. This feature helps user to automate Day 0 configuration.
+  This feature includes three modules:
+	- ibm_svc_initial_seutp
+	- ibm_svc_manage_callhome 
+	- ibm_svc_manage_sra
+- By proceeding and using these modules, the user acknowledges that [IBM Privacy Statement](https://www.ibm.com/privacy) has been read and understood.
 
 ### Prerequisite
 
@@ -100,6 +113,8 @@ The modules in the IBM Spectrum Virtualize Ansible collection leverage REST APIs
 1. Using the REST APIs to list more than 2000 objects may create a loss of service from the API side, as it automatically restarts due to memory constraints.
 2. It is not possible to access REST APIs using an IPv6 address on a cluster.
 3. The Ansible collection can run on all IBM Spectrum Virtualize storage versions above 8.1.3, except versions 8.3.1.3 and 8.3.1.4.
+4. At time of release of the SV Ansible v1.7.0 collection, no module is available to automate license agreements acceptance, including EULA.
+   User will be presented with a GUI setup wizard upon user-interface login, whether the Ansible modules have been used for initial configuration or not.
 
 ## Releasing, Versioning and Deprecation
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -25,3 +25,27 @@ releases:
     - description: Manages volume migration between Spectrum Virtualize storage systems
       name: ibm_svc_manage_migration
       namespace: ''
+  1.7.0:
+    release_date: '2021-12-24'
+    changes:
+      release_summary: Added new modules for managing users, user groups and ownership groups. Added modules for configuring
+        Call Home, remote support assistance and initial setup configurations.
+    modules:
+    - description: Manages users on Spectrum Virtualize system
+      name: ibm_svc_manage_user
+      namespace: ''
+    - description: Manages user groups on Spectrum Virtualize system
+      name: ibm_svc_manage_usergroup
+      namespace: ''
+    - description: Manages ownership groups on Spectrum Virtualize storage systems
+      name: ibm_svc_manage_ownershipgroup
+      namespace: ''
+    - description: Manages Call Home configuration on Spectrum Virtualize storage systems
+      name: ibm_svc_manage_callhome
+      namespace: ''
+    - description: Manages remote support assistance on Spectrum Virtualize storage systems
+      name: ibm_svc_manage_sra
+      namespace: ''
+    - description: Allow user to do initial setup configuration on Spectrum Virtualize storage systems
+      name: ibm_svc_initial_setup
+      namespace: ''

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ibm
 name: spectrum_virtualize
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.6.0
+version: 1.7.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -21,6 +21,7 @@ authors:
 - Shilpi Jain <shilpi.jain1@ibm.com>
 - Rohit Kumar <rohit.kumar6@ibm.com>
 - Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
+- Sanjaikumaar M <sanjaikumaar.m@ibm.com>
 
 
 ### OPTIONAL but strongly recommended

--- a/plugins/modules/ibm_svc_auth.py
+++ b/plugins/modules/ibm_svc_auth.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_auth
-short_description: This module generates an authentication token for a user on IBM Spectrum Virtualize Family storage system
+short_description: This module generates an authentication token for a user on IBM Spectrum Virtualize family storage system
 description:
   - Ansible interface to generate the authentication token.
     The token is used to make REST API calls to the storage system.
@@ -97,7 +97,6 @@ token:
     version_added: 1.5.0
 '''
 
-from traceback import format_exc
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec, get_logger
 from ansible.module_utils._text import to_native

--- a/plugins/modules/ibm_svc_host.py
+++ b/plugins/modules/ibm_svc_host.py
@@ -19,7 +19,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_host
-short_description: This module manages hosts on IBM Spectrum Virtualize Family storage systems
+short_description: This module manages hosts on IBM Spectrum Virtualize family storage systems
 version_added: "1.0.0"
 description:
   - Ansible interface to manage 'mkhost', 'chhost', and 'rmhost' host commands.
@@ -31,14 +31,13 @@ options:
         type: str
     state:
         description:
-            - Creates or updates (C(present)), or removes (C(absent)) a host.
+            - Creates or updates (C(present)) or removes (C(absent)) a host.
         choices: [ absent, present ]
         required: true
         type: str
     clustername:
         description:
-            - The hostname or management IP of the
-              Spectrum Virtualize storage system.
+            - The hostname or management IP of the Spectrum Virtualize storage system.
         required: true
         type: str
     domain:
@@ -49,17 +48,17 @@ options:
     username:
         description:
             - REST API username for the Spectrum Virtualize storage system.
-            - The parameters I(username) and I(password) are required if not using 'token' to authenticate a user.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
         type: str
     password:
         description:
             - REST API password for the Spectrum Virtualize storage system.
-            - The parameters I(username) and I(password) are required if not using 'token' to authenticate a user.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
         type: str
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use ibm_svc_auth module.
+            - To generate a token, use the ibm_svc_auth module.
         type: str
         version_added: '1.5.0'
     fcwwpn:
@@ -76,26 +75,24 @@ options:
         type: str
     iogrp:
         description:
-            - Specifies a set of one or more input/output (I/O)
-              groups from which the host can access the volumes.
+            - Specifies a set of one or more input/output (I/O) groups from which the host can access the volumes.
               Once specified, this parameter cannot be modified.
             - Valid when C(state=present), to create a host.
         type: str
     protocol:
         description:
-            - Specifies the protocol used by the host to
-              communicate with the storage system. Only 'scsi' protocol is supported.
+            - Specifies the protocol used by the host to communicate with the storage system. Only 'scsi' protocol is supported.
             - Valid when C(state=present), to create a host.
         type: str
     type:
         description:
             - Specifies the type of host.
-              Valid when C(state=present), to create or modify a host.
+            - Valid when C(state=present), to create or modify a host.
         type: str
     site:
         description:
             - Specifies the site name of the host.
-              Valid when C(state=present), to create or modify a host.
+            - Valid when C(state=present), to create or modify a host.
         type: str
     hostcluster:
         description:

--- a/plugins/modules/ibm_svc_hostcluster.py
+++ b/plugins/modules/ibm_svc_hostcluster.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 #
 # GNU General Public License v3.0+
@@ -17,7 +17,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_hostcluster
-short_description: This module manages host cluster on IBM Spectrum Virtualize Family storage systems
+short_description: This module manages host cluster on IBM Spectrum Virtualize family storage systems
 version_added: "1.5.0"
 description:
   - Ansible interface to manage 'mkhostcluster', 'chhostcluster' and 'rmhostcluster' host commands.
@@ -41,7 +41,7 @@ options:
     domain:
         description:
             - Domain for the Spectrum Virtualize storage system.
-              Valid when hostname is used for the parameter I(clustername).
+            - Valid when hostname is used for the parameter I(clustername).
         type: str
     username:
         description:
@@ -56,19 +56,19 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use ibm_svc_auth module.
+            - To generate a token, use the ibm_svc_auth module.
         type: str
     ownershipgroup:
         description:
             - The name of the ownership group to which the host cluster object is being added.
-              Parameters I(ownershipgroup) and I(noownershipgroup) are mutually exclusive.
+            - Parameters I(ownershipgroup) and I(noownershipgroup) are mutually exclusive.
             - Applies when C(state=present).
         type: str
         version_added: '1.6.0'
     noownershipgroup:
         description:
             - If specified True, the host cluster object is removed from the ownership group to which it belongs.
-              Parameters I(ownershipgroup) and I(noownershipgroup) are mutually exclusive.
+            - Parameters I(ownershipgroup) and I(noownershipgroup) are mutually exclusive.
             - Applies when C(state=present) to modify an existing hostcluster.
         type: bool
         version_added: '1.6.0'

--- a/plugins/modules/ibm_svc_initial_setup.py
+++ b/plugins/modules/ibm_svc_initial_setup.py
@@ -1,0 +1,628 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 IBM CORPORATION
+# Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_initial_setup
+short_description: This module allows users to manage the initial setup configuration on IBM Spectrum Virtualize family storage systems
+version_added: "1.7.0"
+description:
+  - Ansible interface to perform various initial system configuration
+options:
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the ibm_svc_auth module.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+    system_name:
+        description:
+            - Specifies system name.
+        type: str
+    dnsname:
+        description:
+            - Specifies a unique name for the system DNS server being created.
+            - Maximum two DNS servers can be configured. User needs to provide the complete list of DNS servers that are required to be configured.
+        type: list
+        elements: str
+    dnsip:
+        description:
+            - Specifies the DNS server Internet Protocol (IP) address.
+        type: list
+        elements: str
+    ntpip:
+        description:
+            - Specifies the IPv4 address or fully qualified domain name (FQDN) for the Network Time Protocol (NTP) server.
+            - To remove an already configured NTP IP, user must specify 0.0.0.0.
+        type: str
+    time:
+        description:
+            - Specifies the time to which the system must be set.
+            - This value must be in the following format MMDDHHmmYYYY (where M is month, D is day, H is hour, m is minute, and Y is year).
+        type: str
+    timezone:
+        description:
+            - Specifies the time zone to set for the system.
+        type: str
+    license_key:
+        description:
+            - Provides the license key to activate a feature that contains 16 hexadecimal characters organized in four groups
+              of four numbers with each group separated by a hyphen (such as 0123-4567-89AB-CDEF).
+        type: list
+        elements: str
+    remote:
+        description:
+            - Changes system licensing for remote-copy functions such as Metro Mirror, Global Mirror, and HyperSwap.
+            - Depending on the type of system, specify a capacity value in terabytes (TB) or specify the total number of
+              internal and external enclosures that user has licensed on the system.
+              There must be an enclosure license for all enclosures.
+        type: int
+    virtualization:
+        description:
+            - Changes system licensing for the Virtualization function.
+            - Depending on the type of system, specify a capacity value in terabytes (TB) or specify the total number of
+              storage capacity units (SCUs) that user is licensed to virtualize across tiers of storage on the system or
+              specify the number of enclosures of external storage that user is authorized to use.
+        type: int
+    compression:
+        description:
+            - Changes system licensing for the compression function.
+            - Depending on the type of system, specify a capacity value in terabytes (TB) or specify the total number of
+              storage capacity units (SCUs) that user is licensed to virtualize across tiers of storage on the system or
+              specify the total number of internal and external enclosures that user has licensed on the system.
+        type: int
+    flash:
+        description:
+            - Changes system licensing for the FlashCopy function.
+            - Depending on the type of system, specify a capacity value in terabytes (TB) or specify the total number of
+              internal and external enclosures for the FlashCopy function.
+        type: int
+    cloud:
+        description:
+            - Specifies the number of enclosures for the transparent cloud tiering function.
+        type: int
+    easytier:
+        description:
+            - Specifies the number of enclosures on which user can run Easy Tier.
+        type: int
+    physical_flash:
+        description:
+            - For physical disk licensing, this parameter enables or disables the FlashCopy function.
+        type: str
+        choices: [ 'on', 'off' ]
+        default: 'off'
+    encryption:
+        description:
+            - Specifies whether the encryption license function is enabled or disabled.
+        type: str
+        choices: [ 'on', 'off' ]
+author:
+    - Shilpi Jain (@Shilpi-J)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Using Spectrum Virtualize collection to perform initial setup on FlashSystem 9200
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Initial configuration on FlashSystem 9200
+      ibm_svc_initial_setup:
+        clustername: "{{clustername}}"
+        domain: "{{domain}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        log_path: /tmp/playbook.debug
+        system_name: cluster_test_0
+        time: 101009142021
+        timezone: 200
+        remote: 50
+        virtualization: 50
+        flash: 50
+        license_key:
+          - 0123-4567-89AB-CDEF
+          - 8921-4567-89AB-GHIJ
+
+- name: Using Spectrum Virtualize collection to set DNS servers
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Add DNS servers
+      ibm_svc_initial_setup:
+        clustername: "{{clustername}}"
+        domain: "{{domain}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        log_path: /tmp/playbook.debug
+        system_name: cluster_test_
+        dnsname:
+          - dns_01
+          - dns_02
+        dnsip:
+          - '1.1.1.1'
+          - '2.2.2.2'
+
+- name: Using Spectrum Virtualize collection to delete DNS servers
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Delete dns_02 server
+      ibm_svc_initial_setup:
+        clustername: "{{clustername}}"
+        domain: "{{domain}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        log_path: /tmp/playbook.debug
+        system_name: cluster_test_
+        dnsname:
+          - dns_01
+        dnsip:
+          - '1.1.1.1'
+'''
+
+RETURN = '''
+'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec, get_logger
+from ansible.module_utils._text import to_native
+
+
+class IBMSVCInitialSetup(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+
+        argument_spec.update(
+            dict(
+                system_name=dict(type='str'),
+                dnsname=dict(type='list', elements='str'),
+                dnsip=dict(type='list', elements='str'),
+                ntpip=dict(type='str'),
+                time=dict(type='str'),
+                timezone=dict(type='str'),
+                license_key=dict(type='list', elements='str', no_log=True),
+                remote=dict(type='int'),
+                virtualization=dict(type='int'),
+                flash=dict(type='int'),
+                compression=dict(type='int'),
+                cloud=dict(type='int'),
+                easytier=dict(type='int'),
+                physical_flash=dict(type='str', default='off', choices=['on', 'off']),
+                encryption=dict(type='str', choices=['on', 'off'])
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, log_path)
+        self.log = log.info
+
+        self.system_data = ""
+        self.changed = False
+        self.message = ""
+
+        # Optional
+        self.systemname = self.module.params.get('system_name', '')
+        self.dnsname = self.module.params.get('dnsname', '')
+        self.dnsip = self.module.params.get('dnsip', '')
+        self.ntpip = self.module.params.get('ntpip', '')
+        self.time = self.module.params.get('time', '')
+        self.timezone = self.module.params.get('timezone', '')
+
+        # license related parameters
+        self.license_key = self.module.params.get('license_key', '')
+        self.remote = self.module.params.get('remote', '')
+        self.virtualization = self.module.params.get('virtualization', '')
+        self.compression = self.module.params.get('compression', '')
+        self.flash = self.module.params.get('flash', '')
+        self.cloud = self.module.params.get('cloud', '')
+        self.easytier = self.module.params.get('easytier', '')
+        self.physical_flash = self.module.params.get('physical_flash', '')
+        self.encryption = self.module.params.get('encryption', '')
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path,
+            token=self.module.params['token']
+        )
+
+    def basic_checks(self):
+        if self.time and self.ntpip:
+            self.module.fail_json(msg='Either NTP or time should be given')
+
+        if self.dnsname and self.dnsip:
+            if len(self.dnsname) != len(self.dnsip):
+                self.module.fail_json(msg='To configure DNS, DNS IP and DNS server name must be given.')
+
+    def get_system_info(self):
+        self.log("Entering function get_system_info")
+        self.system_data = self.restapi.svc_obj_info(cmd='lssystem', cmdopts=None, cmdargs=None)
+        return self.system_data
+
+    def systemname_update(self):
+        cmd = 'chsystem'
+        cmdopts = {}
+        cmdopts['name'] = self.systemname
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        # Any error will have been raised in svc_run_command
+        self.changed = True
+        self.log("System Name: %s updated", cmdopts)
+        self.message += " System name [%s] updated." % self.systemname
+
+    def ntp_update(self, ip):
+        cmd = 'chsystem'
+        cmdopts = {}
+        cmdopts['ntpip'] = ip
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        # Any error will have been raised in svc_run_command
+        self.changed = True
+        self.log("NTP IP: %s updated", cmdopts)
+        if self.ntpip:
+            self.message += " NTP IP [%s] updated." % self.ntpip
+
+    def systemtime_update(self):
+        cmd = 'setsystemtime'
+        cmdopts = {}
+        cmdopts['time'] = self.time
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        # Any error will have been raised in svc_run_command
+        self.changed = True
+        self.log("Time: %s updated", self.time)
+        self.message += " Time [%s] updated." % self.time
+
+    def timezone_update(self):
+        cmd = 'settimezone'
+        cmdopts = {}
+        cmdopts['timezone'] = self.timezone
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        # Any error will have been raised in svc_run_command
+        # chhost does not output anything when successful.
+        self.changed = True
+        self.log("Properties: Time zone %s updated", self.timezone)
+        self.message += " Timezone [%s] updated." % self.timezone
+
+    def system_update(self, data):
+        name_change_required = False
+        ntp_change_required = False
+        time_change_required = False
+        timezone_change_required = False
+        tz = (None, None)
+
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        if self.systemname and self.systemname != data['name']:
+            self.log("Name change detected")
+            name_change_required = True
+        if self.ntpip and self.ntpip != data['cluster_ntp_IP_address']:
+            self.log("NTP change detected")
+            ntp_change_required = True
+        if self.time and data['cluster_ntp_IP_address'] is not None:
+            self.log("TIME change detected, clearing NTP IP")
+            ntp_change_required = True
+        if self.time:
+            self.log("TIME change detected")
+            time_change_required = True
+        if data['time_zone']:
+            tz = data['time_zone'].split(" ", 1)
+        if self.timezone and (tz[0] != self.timezone):
+            timezone_change_required = True
+
+        if name_change_required:
+            self.systemname_update()
+        if ntp_change_required:
+            self.log("updating system properties '%s, %s'", self.systemname, self.ntpip)
+            if self.ntpip:
+                ip = self.ntpip
+            if self.time and ntp_change_required:
+                ip = '0.0.0.0'
+            self.ntp_update(ip)
+
+        if time_change_required:
+            self.systemtime_update()
+
+        if timezone_change_required:
+            self.timezone_update()
+
+    def get_existing_dnsservers(self):
+        merged_result = []
+
+        data = self.restapi.svc_obj_info(cmd='lsdnsserver', cmdopts=None, cmdargs=None)
+
+        if isinstance(data, list):
+            for d in data:
+                merged_result.append(d)
+        else:
+            merged_result = data
+
+        return merged_result
+
+    def dns_configure(self):
+        dns_add_remove = False
+        modify = {}
+        existing_dns = {}
+        existing_dns_server = []
+        existing_dns_ip = []
+
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        dns_data = self.get_existing_dnsservers()
+        self.log("dns_data=%s", dns_data)
+
+        if (self.dnsip and self.dnsname) or (self.dnsip == "" and self.dnsname == ""):
+            for server in dns_data:
+                existing_dns_server.append(server['name'])
+                existing_dns_ip.append(server['IP_address'])
+                existing_dns[server['name']] = server['IP_address']
+            for name, ip in zip(self.dnsname, self.dnsip):
+                if name == 'None':
+                    self.log(" Empty DNS configuration is provided.")
+                    return
+                if name in existing_dns:
+                    if existing_dns[name] != ip:
+                        self.log("update, diff IP.")
+                        modify[name] = ip
+                    else:
+                        self.log("no update, same IP.")
+
+            if (set(existing_dns_server)).symmetric_difference(set(self.dnsname)):
+                dns_add_remove = True
+
+        if modify:
+            for item in modify:
+                self.restapi.svc_run_command(
+                    'chdnsserver',
+                    {'ip': modify[item]}, [item]
+                )
+            self.changed = True
+            self.message += " DNS %s modified." % modify
+
+        if dns_add_remove:
+            to_be_added, to_be_removed = False, False
+            to_be_removed = list(set(existing_dns_server) - set(self.dnsname))
+            if to_be_removed:
+                for item in to_be_removed:
+                    self.restapi.svc_run_command(
+                        'rmdnsserver', None,
+                        [item]
+                    )
+                    self.changed = True
+                self.message += " DNS server %s removed." % to_be_removed
+
+            to_be_added = list(set(self.dnsname) - set(existing_dns_server))
+            to_be_added_ip = list(set(self.dnsip) - set(existing_dns_ip))
+            if any(to_be_added):
+                for dns_name, dns_ip in zip(to_be_added, to_be_added_ip):
+                    if dns_name:
+                        self.log('%s %s', dns_name, dns_ip)
+                        self.restapi.svc_run_command(
+                            'mkdnsserver',
+                            {'name': dns_name, 'ip': dns_ip}, cmdargs=None
+                        )
+                        self.changed = True
+                self.message += " DNS server %s added." % to_be_added
+        elif not modify:
+            self.log("No DNS Changes")
+
+    def license_probe(self):
+        props = []
+
+        cmd = 'lslicense'
+        cmdopts = {}
+        data = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+
+        if self.remote and int(data['license_remote']) != self.remote:
+            props += ['remote']
+        if self.virtualization and int(data['license_virtualization']) != self.virtualization:
+            props += ['virtualization']
+        if self.compression:
+            if (self.system_data['product_name'] == "IBM Storwize V7000") or (self.system_data['product_name'] == "IBM FlashSystem 7200"):
+                if (int(data['license_compression_enclosures']) != self.compression):
+                    self.log("license_compression_enclosure=%d", int(data['license_compression_enclosures']))
+                    props += ['compression']
+            else:
+                if (int(data['license_compression_capacity']) != self.compression):
+                    self.log("license_compression_capacity=%d", int(data['license_compression_capacity']))
+                    props += ['compression']
+        if self.flash and int(data['license_flash']) != self.flash:
+            props += ['flash']
+        if self.cloud and int(data['license_cloud_enclosures']) != self.cloud:
+            props += ['cloud']
+        if self.easytier and int(data['license_easy_tier']) != self.easytier:
+            props += ['easytier']
+        if self.physical_flash and data['license_physical_flash'] != self.physical_flash:
+            props += ['physical_flash']
+
+        self.log("props: %s", props)
+        return props
+
+    def license_update(self, modify):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'chlicense'
+
+        for license in modify:
+            cmdopts = {}
+            cmdopts[license] = getattr(self, license)
+            self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+
+        self.changed = True if modify else False
+
+        if self.encryption:
+            cmdopts = {}
+            cmdopts['encryption'] = self.encryption
+            self.changed = True
+            self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+
+        self.log("Licensed functions %s updated", modify)
+        self.message += " Licensed functions %s updated." % modify
+
+    def license_key_update(self):
+        existing_license_keys = []
+        license_id_pairs = {}
+        license_add_remove = False
+
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        for key in self.license_key:
+            if key == 'None':
+                self.log(" Empty License key list provided")
+                return
+
+        cmd = 'lsfeature'
+        cmdopts = {}
+        feature_list = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        for feature in feature_list:
+            existing_license_keys.append(feature['license_key'])
+            license_id_pairs[feature['license_key']] = feature['id']
+        self.log("existing licenses=%s, license_id_pairs=%s", existing_license_keys, license_id_pairs)
+
+        if (set(existing_license_keys)).symmetric_difference(set(self.license_key)):
+            license_add_remove = True
+
+        if license_add_remove:
+            deactivate_license_keys, activate_license_keys = False, False
+            deactivate_license_keys = list(set(existing_license_keys) - set(self.license_key))
+            self.log('deactivate_license_keys %s ', deactivate_license_keys)
+            if deactivate_license_keys:
+                for item in deactivate_license_keys:
+                    if not item:
+                        self.log('%s item', [license_id_pairs[item]])
+                        self.restapi.svc_run_command(
+                            'deactivatefeature',
+                            None, [license_id_pairs[item]]
+                        )
+                        self.changed = True
+                        self.log('%s deactivated', deactivate_license_keys)
+                self.message += " License %s deactivated." % deactivate_license_keys
+
+            activate_license_keys = list(set(self.license_key) - set(existing_license_keys))
+            self.log('activate_license_keys %s ', activate_license_keys)
+            if activate_license_keys:
+                for item in activate_license_keys:
+                    if item:
+                        self.restapi.svc_run_command(
+                            'activatefeature',
+                            {'licensekey': item}, None
+                        )
+                        self.changed = True
+                        self.log('%s activated', activate_license_keys)
+                self.message += " License %s activated." % activate_license_keys
+        else:
+            self.message += " No license Changes."
+
+    def apply(self):
+        msg = None
+        modify = []
+
+        self.basic_checks()
+
+        self.system_data = self.get_system_info()
+        if self.systemname or self.ntpip or self.timezone or self.time:
+            self.system_update(self.system_data)
+
+        # DNS configuration
+        self.dns_configure()
+
+        # For honour based licenses
+        modify = self.license_probe()
+        if modify:
+            self.license_update(modify)
+
+        # For key based licenses
+        if self.license_key:
+            self.license_key_update()
+
+        if self.changed:
+            if self.module.check_mode:
+                msg = "skipping changes due to check mode."
+            else:
+                msg = self.message
+        else:
+            msg = "No modifications required. Exiting with no changes."
+
+        self.module.exit_json(msg=msg, changed=self.changed)
+
+
+def main():
+    v = IBMSVCInitialSetup()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_svc_manage_callhome.py
+++ b/plugins/modules/ibm_svc_manage_callhome.py
@@ -1,0 +1,903 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 IBM CORPORATION
+# Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_manage_callhome
+short_description: This module manages Call Home feature configuration on IBM Spectrum Virtualize
+                   family storage systems
+description:
+  - Ansible interface to manage cloud and email Call Home feature.
+version_added: "1.7.0"
+options:
+    state:
+        description:
+            - Enables or updates (C(enabled)) or disables (C(disabled)) Call Home feature.
+        choices: [ enabled, disabled ]
+        required: true
+        type: str
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        type: str
+        required: true
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the ibm_svc_auth module.
+        type: str
+    callhome_type:
+        description:
+            - Specifies the transmission type.
+        choices: [ 'cloud services', 'email', 'both' ]
+        required: True
+        type: str
+    proxy_type:
+        description:
+            - Specifies the proxy type.
+            - Required when C(state=enabled), to create or modify Call Home feature.
+            - Proxy gets deleted for C(proxy_type=no_proxy).
+            - The parameter is mandatory when C(callhome_type='cloud services')) or C(callhome_type='both').
+        choices: [ open_proxy, basic_authentication, certificate, no_proxy ]
+        type: str
+    proxy_url:
+        description:
+            - Specifies the proxy server URL with a protocol prefix in fully qualified domain name format.
+            - Applies when C(state=enabled) and C(proxy_type=open_proxy) or C(proxy_type=basic_authentication).
+        type: str
+    proxy_port:
+        description:
+            - Specifies the proxy server port number.
+              The value must be in the range 1 - 65535.
+            - Applies when C(state=enabled) and C(proxy_type=open_proxy) or C(proxy_type=basic_authentication).
+        type: int
+    proxy_username:
+        description:
+            - Specifies the proxy's username.
+            - Applies when C(state=enabled) and C(proxy_type=basic_authentication).
+        type: str
+    proxy_password:
+        description:
+            - Specifies the proxy's password.
+            - Applies when C(state=enabled) and C(proxy_type=basic_authentication).
+        type: str
+    sslcert:
+        description:
+            - Specifies the file path of proxy's certificate.
+            - Applies when C(state=enabled) and C(proxy_type=certificate).
+        type: str
+    company_name:
+        description:
+            - Specifies the user's organization as it should appear in Call Home email.
+            - Required when C(state=enabled).
+        type: str
+    address:
+        description:
+            - Specifies the first line of the user's address as it should appear in Call Home email.
+            - Required when C(state=enabled).
+        type: str
+    city:
+        description:
+            - Specifies the user's city as it should appear in Call Home email.
+            - Required when C(state=enabled).
+        type: str
+    province:
+        description:
+            - Specifies the user's state or province as it should appear in Call Home email.
+            - Required when C(state=enabled).
+        type: str
+    postalcode:
+        description:
+            - Specifies the user's zip code or postal code as it should appear in Call Home email.
+            - Required when C(state=enabled).
+        type: str
+    country:
+        description:
+            - Specifies the country in which the machine resides as it should appear in Call Home email.
+            - Required when C(state=enabled).
+        type: str
+    location:
+        description:
+            - Specifies the physical location of the system that has reported the error.
+            - Required when C(state=enabled).
+        type: str
+    contact_name:
+        description:
+            - Specifies the name of the person receiving the email.
+            - Required when C(state=enabled).
+        type: str
+    contact_email:
+        description:
+            - Specifies the email of the person.
+            - Required when C(state=enabled).
+        type: str
+    phonenumber_primary:
+        description:
+            - Specifies the primary contact telephone number.
+            - Required when C(state=enabled).
+        type: str
+    phonenumber_secondary:
+        description:
+            - Specifies the secondary contact telephone number.
+            - Required when C(state=enabled).
+        type: str
+    serverIP:
+        description:
+            - Specifies the IP address of the email server.
+            - Required when C(state=enabled) and C(callhome_type=email) or C(callhome_type=both).
+        type: str
+    serverPort:
+        description:
+            - Specifies the port number of the email server.
+            - The value must be in the range 1 - 65535.
+            - Required when C(state=enabled) and C(callhome_type=email) or C(callhome_type=both).
+        type: int
+    inventory:
+        description:
+            - Specifies whether the recipient mentioned in parameter I(contact_email) receives inventory email notifications.
+            - Applies when C(state=enabled).
+              If unspecified, default value 'off' will be used.
+        choices: ['on', 'off']
+        type: str
+    invemailinterval:
+        description:
+            - Specifies the interval at which inventory emails are sent to the configured email recipients.
+            - The interval is measured in days. The value must be in the range 0 - 15.
+            - Setting the value to '0' turns off the inventory email notification function.
+              Valid if I(inventory) is set to 'on'.
+        type: int
+    enhancedcallhome:
+        description:
+            - Specifies that the Call Home function is to send enhanced reports to the support center.
+            - Applies when C(state=enabled).
+            - If unspecified, default value 'off' will be used.
+        choices: ['on', 'off']
+        type: str
+    censorcallhome:
+        description:
+            - Specifies that sensitive data is deleted from the enhanced Call Home data.
+            - Applies when C(state=enabled).
+            - If unspecified, default value 'off' will be used.
+        choices: ['on', 'off']
+        type: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+author:
+    - Sreshtant Bohidar(@Sreshtant-Bohidar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+---
+- name: Using IBM Spectrum Virtualize collection to enable Call Home feature.
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Configure callhome with both email and cloud
+      ibm_svc_manage_callhome:
+        clustername: "{{ clustername }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        log_path: "/tmp/playbook.debug"
+        state: "enabled"
+        callhome_type: "both"
+        address: "{{ address }}"
+        city: "{{ city }}"
+        company_name: "{{ company_name }}"
+        contact_email: "{{ contact_email }}"
+        contact_name: "{{ contact_name }}"
+        country: "{{ country }}"
+        location: "{{ location }}"
+        phonenumber_primary: "{{ primary_phonenumber }}"
+        postalcode: "{{ postal_code }}"
+        province: "{{ province }}"
+        proxy_type: "{{ proxy_type }}"
+        proxy_url: "{{ proxy_url }}"
+        proxy_port: "{{ proxy_port }}"
+        serverIP: "{{ server_ip }}"
+        serverPort: "{{ server_port }}"
+        inventory: "on"
+        invemailinterval: 1
+        enhancedcallhome: "on"
+        censorcallhome: "on"
+
+'''
+RETURN = '''
+'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec, get_logger
+from ansible.module_utils._text import to_native
+import time
+
+
+class IBMSVCCallhome(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                state=dict(type='str', required=True, choices=['enabled', 'disabled']),
+                callhome_type=dict(type='str', required=True, choices=['cloud services', 'email', 'both']),
+                proxy_type=dict(type='str', choices=['open_proxy', 'basic_authentication', 'certificate', 'no_proxy']),
+                proxy_url=dict(type='str'),
+                proxy_port=dict(type='int'),
+                proxy_username=dict(type='str'),
+                proxy_password=dict(type='str', no_log=True),
+                sslcert=dict(type='str'),
+                company_name=dict(type='str'),
+                address=dict(type='str'),
+                city=dict(type='str'),
+                province=dict(type='str'),
+                postalcode=dict(type='str'),
+                country=dict(type='str'),
+                location=dict(type='str'),
+                contact_name=dict(type='str'),
+                contact_email=dict(type='str'),
+                phonenumber_primary=dict(type='str'),
+                phonenumber_secondary=dict(type='str'),
+                serverIP=dict(type='str'),
+                serverPort=dict(type='int'),
+                inventory=dict(type='str', choices=['on', 'off']),
+                invemailinterval=dict(type='int'),
+                enhancedcallhome=dict(type='str', choices=['on', 'off']),
+                censorcallhome=dict(type='str', choices=['on', 'off'])
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, log_path)
+        self.log = log.info
+
+        # Required
+        self.state = self.module.params['state']
+        self.callhome_type = self.module.params['callhome_type']
+        self.company_name = self.module.params['company_name']
+        self.address = self.module.params['address']
+        self.city = self.module.params['city']
+        self.province = self.module.params['province']
+        self.postalcode = self.module.params['postalcode']
+        self.country = self.module.params['country']
+        self.location = self.module.params['location']
+        self.contact_name = self.module.params['contact_name']
+        self.contact_email = self.module.params['contact_email']
+        self.phonenumber_primary = self.module.params['phonenumber_primary']
+
+        # Optional
+        self.proxy_type = self.module.params.get('proxy_type', False)
+        self.proxy_url = self.module.params.get('proxy_url', False)
+        self.proxy_port = self.module.params.get('proxy_port', False)
+        self.proxy_username = self.module.params.get('proxy_username', False)
+        self.proxy_password = self.module.params.get('proxy_password', False)
+        self.sslcert = self.module.params.get('sslcert', False)
+        self.phonenumber_secondary = self.module.params.get('phonenumber_secondary', False)
+        self.serverIP = self.module.params.get('serverIP', False)
+        self.serverPort = self.module.params.get('serverPort', False)
+        self.inventory = self.module.params.get('inventory', False)
+        self.invemailinterval = self.module.params.get('invemailinterval', False)
+        self.enhancedcallhome = self.module.params.get('enhancedcallhome', False)
+        self.censorcallhome = self.module.params.get('censorcallhome', False)
+
+        # creating an instance of IBMSVCRestApi
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path,
+            token=self.module.params['token']
+        )
+
+    def basic_checks(self):
+        # setting the default value if unspecified
+        if not self.inventory:
+            self.inventory = 'off'
+        if not self.enhancedcallhome:
+            self.enhancedcallhome = 'off'
+        if not self.censorcallhome:
+            self.censorcallhome = 'off'
+        # perform some basic handling for few parameters
+        if self.inventory == 'on':
+            if not self.invemailinterval:
+                self.module.fail_json(msg="Parameter [invemailinterval] should be configured to use [inventory]")
+        if self.invemailinterval:
+            if self.inventory == 'off':
+                self.module.fail_json(msg="The parameter [inventory] should be configured with 'on' while setting [invemailinterval]")
+            if self.invemailinterval not in range(1, 16):
+                self.module.fail_json(msg="Parameter [invemailinterval] supported range is 0 to 15")
+        if isinstance(self.serverPort, int):
+            if self.serverPort not in range(1, 65536):
+                self.module.fail_json(msg="Parameter [serverPort] must be in range[1-65535]")
+        if isinstance(self.proxy_port, int):
+            if self.proxy_port not in range(1, 65536):
+                self.module.fail_json(msg="Parameter [proxy_port] must be in range[1-65535]")
+        if not self.state:
+            self.module.fail_json(msg="Missing mandatory parameter: state")
+        if not self.callhome_type:
+            self.module.fail_json(msg="Missing mandatory parameter: callhome_type")
+        if (self.callhome_type in ['email', 'both']) and (not self.serverIP or not self.serverPort) and (self.state == 'enabled'):
+            self.module.fail_json(msg="Parameters: serverIP, serverPort are required when callhome_type is email/both")
+        if self.state == "enabled" and self.proxy_type in ["cloud services", "both"] and self.proxy_type:
+            if self.proxy_type == 'open_proxy' and (not self.proxy_url or not self.proxy_port):
+                self.module.fail_json(msg="Parameters [proxy_url, proxy_port] required when proxy_type=open_proxy")
+            if self.proxy_type == 'basic_authentication' and (not self.proxy_url or not self.proxy_port or not self.proxy_username or not self.proxy_password):
+                self.module.fail_json(msg="Parameters [proxy_url, proxy_port, proxy_username, proxy_password] required when proxy_type=basic_authentication")
+            if self.proxy_type == 'certificate' and (not self.proxy_url or not self.proxy_port or not self.sslcert):
+                self.module.fail_json(msg="Parameters [proxy_url, proxy_port, sslcert] required when proxy_type=certificate")
+        if self.state == 'enabled':
+            parameters = {
+                'callhome_type': self.callhome_type,
+                'company_name': self.company_name,
+                'address': self.address,
+                'city': self.city,
+                'province': self.province,
+                'country': self.country,
+                'location': self.location,
+                'contact_name': self.contact_name,
+                'contact_email': self.contact_email,
+                'phonenumber_primary': self.phonenumber_primary,
+            }
+            parameter_not_provided = []
+            for parameter in parameters:
+                if not parameters[parameter]:
+                    parameter_not_provided.append(parameter)
+            if parameter_not_provided:
+                self.module.fail_json(msg="Parameters {0} are required when state is 'enabled'".format(parameter_not_provided))
+
+    # function to fetch lssystem data
+    def get_system_data(self):
+        return self.restapi.svc_obj_info('lssystem', cmdopts=None, cmdargs=None)
+
+    # function to probe lssystem data
+    def probe_system(self, data):
+        modify = {}
+        if self.invemailinterval:
+            if self.invemailinterval != data['inventory_mail_interval']:
+                modify['invemailinterval'] = self.invemailinterval
+        if self.enhancedcallhome:
+            if self.enhancedcallhome != data['enhanced_callhome']:
+                modify['enhancedcallhome'] = self.enhancedcallhome
+        if self.censorcallhome:
+            if self.censorcallhome != data['enhanced_callhome']:
+                modify['censorcallhome'] = self.censorcallhome
+        return modify
+
+    # function to execute chsystem commands
+    def update_system(self, modify):
+        command = 'chsystem'
+        command_options = modify
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log("Chsystem commands executed.")
+
+    # function to fetch existing email user
+    def get_existing_email_user_data(self):
+        data = {}
+        email_data = self.restapi.svc_obj_info(cmd='lsemailuser', cmdopts=None, cmdargs=None)
+        for item in email_data:
+            if item['address'] == self.contact_email:
+                data = item
+        return data
+
+    # function to check if email server exists or not
+    def check_email_server_exists(self):
+        status = False
+        data = self.restapi.svc_obj_info(cmd='lsemailserver', cmdopts=None, cmdargs=None)
+        for item in data:
+            if item['IP_address'] == self.serverIP and int(item['port']) == self.serverPort:
+                status = True
+                break
+        return status
+
+    # function to check if email user exists or not
+    def check_email_user_exists(self):
+        temp = {}
+        data = self.restapi.svc_obj_info(cmd='lsemailuser', cmdopts=None, cmdargs=None)
+        for item in data:
+            if item['address'] == self.contact_email:
+                temp = item
+                break
+        return temp
+
+    # function to create an email server
+    def create_email_server(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        self.log("Creating email server '%s:%s'.", self.serverIP, self.serverPort)
+        command = 'mkemailserver'
+        command_options = {
+            'ip': self.serverIP,
+            'port': self.serverPort,
+        }
+        cmdargs = None
+        result = self.restapi.svc_run_command(command, command_options, cmdargs)
+        if 'message' in result:
+            self.changed = True
+            self.log("create email server result message '%s'", (result['message']))
+        else:
+            self.module.fail_json(
+                msg="Failed to create email server [%s:%s]" % (self.serverIP, self.serverPort)
+            )
+
+    # function to update email user
+    def update_email_user(self, data, id):
+        command = "chemailuser"
+        command_options = data
+        cmdargs = [id]
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log('Email user updated successfully.')
+
+    # function to manage support email user
+    def manage_support_email_user(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        support_email = {}
+        selected_email_id = ''
+        t = -1 * ((time.timezone / 60) / 60)
+        if t >= -8 and t <= -4:
+            # for US timezone, callhome0@de.ibm.com is used
+            selected_email_id = 'callhome0@de.ibm.com'
+        else:
+            # for ROW, callhome1@de.ibm.com is used
+            selected_email_id = 'callhome1@de.ibm.com'
+        existing_user = self.restapi.svc_obj_info('lsemailuser', cmdopts=None, cmdargs=None)
+        if existing_user:
+            for user in existing_user:
+                if user['user_type'] == 'support':
+                    support_email = user
+        if not support_email:
+            self.log("Creating support email user '%s'.", selected_email_id)
+            command = 'mkemailuser'
+            command_options = {
+                'address': selected_email_id,
+                'usertype': 'support',
+                'info': 'off',
+                'warning': 'off',
+            }
+            if self.inventory:
+                command_options['inventory'] = self.inventory
+            cmdargs = None
+            result = self.restapi.svc_run_command(command, command_options, cmdargs)
+            if 'message' in result:
+                self.changed = True
+                self.log("create support email user result message '%s'", (result['message']))
+            else:
+                self.module.fail_json(
+                    msg="Failed to support create email user [%s]" % (self.contact_email)
+                )
+        else:
+            modify = {}
+            if support_email['address'] != selected_email_id:
+                modify['address'] = selected_email_id
+            if self.inventory:
+                if support_email['inventory'] != self.inventory:
+                    modify['inventory'] = self.inventory
+            if modify:
+                self.restapi.svc_run_command(
+                    'chemailuser',
+                    modify,
+                    [support_email['id']]
+                )
+                self.log("Updated support user successfully.")
+
+    # function to create an email user
+    def create_email_user(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        self.log("Creating email user '%s'.", self.contact_email)
+        command = 'mkemailuser'
+        command_options = {
+            'address': self.contact_email,
+            'usertype': 'local',
+        }
+        if self.inventory:
+            command_options['inventory'] = self.inventory
+        cmdargs = None
+        result = self.restapi.svc_run_command(command, command_options, cmdargs)
+        if 'message' in result:
+            self.changed = True
+            self.log("Create email user result message '%s'.", (result['message']))
+        else:
+            self.module.fail_json(
+                msg="Failed to create email user [%s]" % (self.contact_email)
+            )
+
+    # function to enable email callhome
+    def enable_email_callhome(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = "startemail"
+        command_options = {}
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log("Email callhome enabled.")
+
+    # function to disable email callhome
+    def disable_email_callhome(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = "stopemail"
+        command_options = {}
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log("Email callhome disabled.")
+
+    # function to update email data
+    def update_email_data(self):
+
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = "chemail"
+        command_options = {}
+        if self.contact_email:
+            command_options['reply'] = self.contact_email
+        if self.contact_name:
+            command_options['contact'] = self.contact_name
+        if self.phonenumber_primary:
+            command_options['primary'] = self.phonenumber_primary
+        if self.phonenumber_secondary:
+            command_options['alternate'] = self.phonenumber_secondary
+        if self.location:
+            command_options['location'] = self.location
+        if self.company_name:
+            command_options['organization'] = self.company_name
+        if self.address:
+            command_options['address'] = self.address
+        if self.city:
+            command_options['city'] = self.city
+        if self.province:
+            command_options['state'] = self.province
+        if self.postalcode:
+            command_options['zip'] = self.postalcode
+        if self.country:
+            command_options['country'] = self.country
+        cmdargs = None
+        if command_options:
+            self.restapi.svc_run_command(command, command_options, cmdargs)
+            self.log("Email data successfully updated.")
+
+    # function for checking if proxy server exists
+    def get_existing_proxy(self):
+        data = {}
+        data = self.restapi.svc_obj_info(cmd='lsproxy', cmdopts=None, cmdargs=None)
+        return data
+
+    # function for removing a proxy
+    def remove_proxy(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'rmproxy'
+        command_options = None
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log('Proxy removed successfully.')
+
+    # function for creating a proxy
+    def create_proxy(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'mkproxy'
+        command_options = {}
+        if self.proxy_type == 'open_proxy':
+            if self.proxy_url:
+                command_options['url'] = self.proxy_url
+            if self.proxy_port:
+                command_options['port'] = self.proxy_port
+        elif self.proxy_type == 'basic_authentication':
+            if self.proxy_url:
+                command_options['url'] = self.proxy_url
+            if self.proxy_port:
+                command_options['port'] = self.proxy_port
+            if self.proxy_username:
+                command_options['username'] = self.proxy_username
+            if self.proxy_password:
+                command_options['password'] = self.proxy_password
+        elif self.proxy_type == 'certificate':
+            if self.proxy_url:
+                command_options['url'] = self.proxy_url
+            if self.proxy_port:
+                command_options['port'] = self.proxy_port
+            if self.sslcert:
+                command_options['sslcert'] = self.sslcert
+
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log("Proxy created successfully.")
+
+    # function for probing existing proxy data
+    def probe_proxy(self, data):
+        modify = {}
+        if self.proxy_type == 'open_proxy':
+            if self.proxy_url:
+                if self.proxy_url != data['url']:
+                    modify['url'] = self.proxy_url
+            if self.proxy_port:
+                if int(self.proxy_port) != int(data['port']):
+                    modify['port'] = self.proxy_port
+        elif self.proxy_type == 'basic_authentication':
+            if self.proxy_url:
+                if self.proxy_url != data['url']:
+                    modify['url'] = self.proxy_url
+            if self.proxy_port:
+                if self.proxy_port != int(data['port']):
+                    modify['port'] = self.proxy_port
+            if self.proxy_username:
+                if self.proxy_username != data['username']:
+                    modify['username'] = self.proxy_username
+            if self.proxy_password:
+                modify['password'] = self.proxy_password
+        elif self.proxy_type == 'certificate':
+            if self.proxy_url:
+                if self.proxy_url != data['url']:
+                    modify['url'] = self.proxy_url
+            if self.proxy_port:
+                if self.proxy_port != int(data['port']):
+                    modify['port'] = self.proxy_port
+            if self.sslcert:
+                modify['sslcert'] = self.sslcert
+        return modify
+
+    # function for updating a proxy
+    def update_proxy(self, data):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'chproxy'
+        command_options = data
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log('Proxy updated successfully.')
+
+    # function for fetching existing cloud callhome data
+    def get_existing_cloud_callhome_data(self):
+        data = {}
+        command = 'lscloudcallhome'
+        command_options = None
+        cmdargs = None
+        data = self.restapi.svc_obj_info(command, command_options, cmdargs)
+        return data
+
+    # function for enabling cloud callhome
+    def enable_cloud_callhome(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'chcloudcallhome'
+        command_options = {
+            'enable': True
+        }
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.changed = True
+        self.log('Cloud callhome enabled.')
+
+    # function for doing connection test for cloud callhome
+    def test_connection_cloud_callhome(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'sendcloudcallhome'
+        command_options = {
+            'connectiontest': True
+        }
+        self.restapi.svc_run_command(command, command_options, None)
+        self.changed = True
+        self.log('Cloud callhome connection tested.')
+        # the connection testing can take some time to complete.
+        time.sleep(3)
+
+    # function for managing proxy server
+    def manage_proxy_server(self):
+        proxy_data = self.get_existing_proxy()
+        if proxy_data['enabled'] == 'no':
+            if self.proxy_type == 'no_proxy':
+                self.log('Proxy already disabled.')
+            else:
+                self.create_proxy()
+                self.changed = True
+        elif proxy_data['enabled'] == 'yes':
+            if self.proxy_type == 'no_proxy':
+                self.remove_proxy()
+                self.changed = True
+            else:
+                modify = self.probe_proxy(proxy_data)
+                if modify:
+                    self.update_proxy(modify)
+                    self.changed = True
+
+    # function for disabling cloud callhome
+    def disable_cloud_callhome(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'chcloudcallhome'
+        command_options = {
+            'disable': True
+        }
+        cmdargs = None
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.log('Cloud callhome disabled.')
+
+    # function to initiate callhome with cloud
+    def initiate_cloud_callhome(self):
+        msg = ''
+        attempts = 0
+        limit_reached = False
+        active_status = False
+        # manage proxy server
+        self.manage_proxy_server()
+        # update email data
+        self.update_email_data()
+        # manage cloud callhome
+        lsdata = self.get_existing_cloud_callhome_data()
+        if lsdata['status'] == 'enabled':
+            # perform connection test
+            self.test_connection_cloud_callhome()
+        else:
+            self.enable_cloud_callhome()
+            # cloud callhome takes some time to get enabled.
+            while not active_status:
+                attempts += 1
+                if attempts > 10:
+                    limit_reached = True
+                    break
+                lsdata = self.get_existing_cloud_callhome_data()
+                if lsdata['status'] == 'enabled':
+                    active_status = True
+                time.sleep(2)
+            if limit_reached:
+                # the module will exit without performing connection test.
+                msg = "Callhome with Cloud is enabled. Please check connection to proxy."
+                self.changed = True
+                return msg
+            if active_status:
+                # perform connection test
+                self.test_connection_cloud_callhome()
+        msg = "Callhome with Cloud enabled successfully."
+        self.changed = True
+        return msg
+
+    # function to initiate callhome with email notifications
+    def initiate_email_callhome(self):
+        msg = ''
+        # manage email server
+        email_server_exists = self.check_email_server_exists()
+        if email_server_exists:
+            self.log("Email server already exists.")
+        else:
+            self.create_email_server()
+            self.changed = True
+        # manage support email user
+        self.manage_support_email_user()
+        # manage local email user
+        email_user_exists = self.check_email_user_exists()
+        if email_user_exists:
+            email_user_modify = {}
+            if email_user_exists['inventory'] != self.inventory:
+                email_user_modify['inventory'] = self.inventory
+            if email_user_modify:
+                self.update_email_user(email_user_modify, email_user_exists['id'])
+        else:
+            self.create_email_user()
+        # manage email data
+        self.update_email_data()
+        # enable email callhome
+        self.enable_email_callhome()
+        msg = "Callhome with email enabled successfully."
+        self.changed = True
+        return msg
+
+    def apply(self):
+        self.changed = False
+        msg = None
+        self.basic_checks()
+        if self.state == 'enabled':
+            # enable cloud callhome
+            if self.callhome_type == 'cloud services':
+                msg = self.initiate_cloud_callhome()
+            # enable email callhome
+            elif self.callhome_type == 'email':
+                msg = self.initiate_email_callhome()
+            # enable both cloud and email callhome
+            elif self.callhome_type == 'both':
+                temp_msg = ''
+                temp_msg += self.initiate_cloud_callhome()
+                temp_msg += ' ' + self.initiate_email_callhome()
+                if temp_msg:
+                    msg = temp_msg
+            # manage chsystem parameters
+            system_data = self.get_system_data()
+            system_modify = self.probe_system(system_data)
+            if system_modify:
+                self.update_system(system_modify)
+        elif self.state == 'disabled':
+            if self.callhome_type == 'cloud services':
+                cloud_callhome_data = self.get_existing_cloud_callhome_data()
+                if cloud_callhome_data['status'] == 'disabled':
+                    msg = "Callhome with cloud already disabled."
+                elif cloud_callhome_data['status'] == 'enabled':
+                    self.disable_cloud_callhome()
+                    msg = "Callhome with cloud disabled successfully."
+                    self.changed = True
+            elif self.callhome_type == 'email':
+                self.disable_email_callhome()
+                msg = "Callhome with email disabled successfully."
+                self.changed = True
+            elif self.callhome_type == 'both':
+                # disable email callhome
+                self.disable_email_callhome()
+                msg = "Callhome with email disabled successfully."
+                self.changed = True
+                # disable cloud callhome
+                cloud_callhome_data = self.get_existing_cloud_callhome_data()
+                if cloud_callhome_data['status'] == 'disabled':
+                    msg += " Callhome with cloud already disabled."
+                elif cloud_callhome_data['status'] == 'enabled':
+                    self.disable_cloud_callhome()
+                    msg += " Callhome with cloud disabled successfully."
+                    self.changed = True
+        self.module.exit_json(msg=msg, changed=self.changed)
+
+
+def main():
+    v = IBMSVCCallhome()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_svc_manage_consistgrp_flashcopy.py
+++ b/plugins/modules/ibm_svc_manage_consistgrp_flashcopy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
 #
 # GNU General Public License v3.0+
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_consistgrp_flashcopy
 short_description: This module manages FlashCopy consistency groups on IBM Spectrum Virtualize
-                   Family storage systems
+                   family storage systems
 description:
   - Ansible interface to manage 'mkfcconsistgrp' and 'rmfcconsistgrp' volume commands.
 version_added: "1.4.0"
@@ -36,8 +36,7 @@ options:
         type: str
     clustername:
         description:
-            - The hostname or management IP of the
-              Spectrum Virtualize storage system.
+            - The hostname or management IP of the Spectrum Virtualize storage system.
         type: str
         required: true
     domain:
@@ -58,7 +57,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use ibm_svc_auth module.
+            - To generate a token, use the ibm_svc_auth module.
         type: str
         version_added: '1.5.0'
     ownershipgroup:
@@ -223,7 +222,7 @@ class IBMSVCFlashcopyConsistgrp(object):
             cmdopts['force'] = self.force
 
         self.log("Deleting fc consistgrp.. Command %s opts %s", cmd, cmdopts)
-        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.name])
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.name])
 
     def fcconsistgrp_probe(self, data):
         props = {}

--- a/plugins/modules/ibm_svc_manage_cv.py
+++ b/plugins/modules/ibm_svc_manage_cv.py
@@ -16,15 +16,14 @@ DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_cv
 short_description: This module manages the change volume for a given volume on IBM
-                   Spectrum Virtualize Family storage systems
+                   Spectrum Virtualize family storage systems
 description:
-  - Ansible interface to manage the change volume in remote copy replication on IBM Spectrum Virtualize Family storage systems.
+  - Ansible interface to manage the change volume in remote copy replication on IBM Spectrum Virtualize family storage systems.
 version_added: "1.3.0"
 options:
   state:
     description:
-      - Creates or updates (C(present)), or removes (C(absent)), a
-        change volume.
+      - Creates or updates (C(present)) or removes (C(absent)), a change volume.
     choices: [absent, present]
     required: true
     type: str
@@ -41,12 +40,12 @@ options:
   basevolume:
     description:
     - Specifies the base volume name (master or auxiliary).
-      Required when C(state=present), to create the change volume.
+    - Required when C(state=present), to create the change volume.
     type: str
   ismaster:
     description:
       - Specifies whether the change volume is being (dis)associated with master cluster.
-        Required when the change volume is being associated or disassociated from the master cluster.
+      - Required when the change volume is being associated or disassociated from the master cluster.
     type: bool
     default: true
   clustername:
@@ -72,7 +71,7 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
     version_added: '1.5.0'
   validate_certs:

--- a/plugins/modules/ibm_svc_manage_flashcopy.py
+++ b/plugins/modules/ibm_svc_manage_flashcopy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_flashcopy
 short_description: This module manages FlashCopy mappings on IBM Spectrum Virtualize
-                   Family storage systems
+                   family storage systems
 description:
   - Ansible interface to manage 'mkfcmap', 'rmfcmap', and 'chfcmap' volume commands.
 version_added: "1.4.0"
@@ -29,8 +29,7 @@ options:
         type: str
     state:
         description:
-            - Creates or updates (C(present)), or removes (C(absent)), a FlashCopy
-              mapping.
+            - Creates or updates (C(present)) or removes (C(absent)) a FlashCopy mapping.
         choices: [ present, absent ]
         required: true
         type: str
@@ -57,7 +56,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use ibm_svc_auth module.
+            - To generate a token, use the ibm_svc_auth module.
         type: str
         version_added: '1.5.0'
     copytype:
@@ -108,8 +107,7 @@ options:
         type: str
     force:
         description:
-            - Brings the target volume online. This parameter is
-              required if the FlashCopy mapping is in the stopped state.
+            - Brings the target volume online. This parameter is required if the FlashCopy mapping is in the stopped state.
             - Valid when C(state=absent), to delete a FlashCopy mapping.
         type: bool
     validate_certs:

--- a/plugins/modules/ibm_svc_manage_migration.py
+++ b/plugins/modules/ibm_svc_manage_migration.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Rohit kumar <rohit.kumar6@ibm.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_migration
-short_description: This module manages volume migration between clusters on IBM Spectrum Virtualize Family storage systems
+short_description: This module manages volume migration between clusters on IBM Spectrum Virtualize family storage systems
 description:
   - Ansible interface to manage the migration commands.
 version_added: "1.6.0"
@@ -83,12 +83,12 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
   remote_token:
     description:
     - The authentication token to verify a user on the partner Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
       Valid when C(state=initiate).
     type: str
   remote_pool:

--- a/plugins/modules/ibm_svc_manage_mirrored_volume.py
+++ b/plugins/modules/ibm_svc_manage_mirrored_volume.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Rohit Kumar <rohit.kumar6@ibm.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_mirrored_volume
 short_description: This module manages mirrored volumes on IBM Spectrum Virtualize
-                   Family storage systems
+                   family storage systems
 description:
   - Ansible interface to manage 'mkvolume', 'addvolumecopy', 'rmvolumecopy', and 'rmvolume' volume commands.
 version_added: "1.4.0"
@@ -55,18 +55,16 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
     version_added: '1.5.0'
   poolA:
     description:
-    - Specifies the name of first storage pool to be used when
-      creating a mirrored volume.
+    - Specifies the name of first storage pool to be used when creating a mirrored volume.
     type: str
   poolB:
     description:
-    - Specifies the name of second storage pool to be used when
-      creating a mirrored volume.
+    - Specifies the name of second storage pool to be used when creating a mirrored volume.
     type: str
   type:
     description:

--- a/plugins/modules/ibm_svc_manage_ownershipgroup.py
+++ b/plugins/modules/ibm_svc_manage_ownershipgroup.py
@@ -1,0 +1,265 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 IBM CORPORATION
+# Author(s): Sanjaikumaar <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_manage_ownershipgroup
+short_description: This module manages ownership group on IBM Spectrum Virtualize family storage systems
+version_added: "1.7.0"
+description:
+  - Ansible interface to manage 'mkownershipgroup' and 'rmownershipgroup' commands.
+options:
+    name:
+        description:
+            - Specifies the name or label for the new ownership group object.
+        required: true
+        type: str
+    state:
+        description:
+            - Creates (C(present)) or removes (C(absent)) an ownership group.
+        choices: [ absent, present ]
+        required: true
+        type: str
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the ibm_svc_auth module.
+        type: str
+    keepobjects:
+        description:
+            - If specified, the objects that currently belong to the ownership group will be kept but will be moved to noownershipgroup.
+            - Applies when C(state=disabled).
+        type: bool
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+author:
+    - Sanjaikumaar M (@sanjaikumaar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Using Spectrum Virtualize collection to create an ownership group
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Create ownership group
+      ibm_svc_manage_ownershipgroup:
+        clustername: "{{ clustername }}"
+        domain: "{{ domain }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        log_path: /tmp/playbook.debug
+        name: newOwner
+        state: present
+
+- name: Using Spectrum Virtualize collection to delete an ownership group
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Delete ownership group
+      ibm_svc_manage_ownershipgroup:
+        clustername: "{{ clustername }}"
+        domain: "{{ domain }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        log_path: /tmp/playbook.debug
+        name: newOwner
+        state: absent
+        keepobjects: true
+'''
+
+RETURN = '''
+'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import (
+    IBMSVCRestApi,
+    svc_argument_spec,
+    get_logger
+)
+
+
+class IBMSVCOwnershipgroup:
+
+    def __init__(self):
+        # Gathering required arguments for the module
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                state=dict(
+                    type='str',
+                    required=True,
+                    choices=['present', 'absent']
+                ),
+                keepobjects=dict(type='bool')
+            )
+        )
+
+        # Initializing ansible module
+        self.module = AnsibleModule(
+            argument_spec=argument_spec,
+            supports_check_mode=True
+        )
+
+        # Required parameters
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional parameters
+        self.keepobjects = self.module.params.get('keepobjects')
+
+        if not self.name:
+            self.module.fail_json(msg='Missing mandatory parameter: name')
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        logger = get_logger(self.__class__.__name__, log_path)
+        self.log = logger.info
+        self.changed = False
+        self.msg = None
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path,
+            token=self.module.params['token']
+        )
+
+    def check_existing_owgroups(self):
+        merged_result = {}
+
+        data = self.restapi.svc_obj_info(cmd='lsownershipgroup', cmdopts=None,
+                                         cmdargs=[self.name])
+
+        if isinstance(data, list):
+            for d in data:
+                merged_result.update(d)
+        else:
+            merged_result = data
+
+        return merged_result
+
+    def create_ownershipgroup(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        if self.keepobjects:
+            self.module.fail_json(
+                msg='Keepobjects should only be passed while deleting ownershipgroup'
+            )
+
+        cmd = 'mkownershipgroup'
+        cmdopts = None
+        cmdargs = ['-name', self.name]
+
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+        self.changed = True
+        self.log('Create ownership group result: %s', result)
+
+    def delete_ownershipgroup(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'rmownershipgroup'
+        cmdopts = None
+        cmdargs = [self.name]
+
+        if self.keepobjects:
+            cmdargs.insert(0, '-keepobjects')
+
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+        self.changed = True
+        self.log('Delete ownership group result: %s', result)
+
+    def apply(self):
+        if self.check_existing_owgroups():
+            if self.state == 'present':
+                self.msg = 'Ownership group (%s) already exist.' % (self.name)
+            else:
+                self.delete_ownershipgroup()
+                self.msg = 'Ownership group (%s) deleted.' % (self.name)
+        else:
+            if self.state == 'absent':
+                self.msg = 'Ownership group (%s) does not exist.' % (self.name)
+            else:
+                self.create_ownershipgroup()
+                self.msg = 'Ownership group (%s) created.' % \
+                           (self.name)
+
+        if self.module.check_mode:
+            self.msg = 'skipping changes due to check mode.'
+
+        self.module.exit_json(
+            changed=self.changed,
+            msg=self.msg
+        )
+
+
+def main():
+    v = IBMSVCOwnershipgroup()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log('Exception in apply(): \n%s', format_exc())
+        v.module.fail_json(msg='Module failed. Error [{0}].'.format(to_native(e)))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_svc_manage_replication.py
+++ b/plugins/modules/ibm_svc_manage_replication.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_replication
 short_description: This module manages remote copies (or rcrelationship) on
-                   IBM Spectrum Virtualize Family storage systems
+                   IBM Spectrum Virtualize family storage systems
 version_added: "1.3.0"
 
 description:
@@ -27,8 +27,7 @@ description:
 options:
   name:
     description:
-      - Specifies the name to assign to the new remote copy relationship
-        or to operate on the existing remote copy.
+      - Specifies the name to assign to the new remote copy relationship or to operate on the existing remote copy.
     type: str
   state:
     description:
@@ -60,15 +59,14 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
     version_added: '1.5.0'
   copytype:
     description:
     - Specifies the mirror type of the remote copy. 'metro' means MetroMirror,
       'global' means GlobalMirror, and 'GMCV' means GlobalMirror with change volume.
-    - If not specified, a MetroMirror remote copy will be created
-      when creating a remote copy C(state=present).
+    - If not specified, a MetroMirror remote copy will be created when creating a remote copy C(state=present).
     type: str
     choices: [ 'metro', 'global' , 'GMCV']
   master:
@@ -94,14 +92,11 @@ options:
     type: bool
   force:
     description:
-    - Specifies that the relationship must be deleted even if it results
-      in the secondary volume containing inconsistent data.
+    - Specifies that the relationship must be deleted even if it results in the secondary volume containing inconsistent data.
     type: bool
   consistgrp:
     description:
-    - Specifies a consistency group that this relationship will join. If not
-      specified by user, the relationship is created as a stand-alone
-      relationship.
+    - Specifies a consistency group that this relationship will join. If not specified by user, the relationship is created as a stand-alone relationship.
     - Applies when C(state=present).
     type: str
   noconsistgrp:

--- a/plugins/modules/ibm_svc_manage_replicationgroup.py
+++ b/plugins/modules/ibm_svc_manage_replicationgroup.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_replicationgroup
 short_description: This module manages remote copy consistency group on
-                   IBM Spectrum Virtualize Family storage systems
+                   IBM Spectrum Virtualize family storage systems
 version_added: "1.3.0"
 description:
   - Ansible interface to manage 'mkrcconsistgrp', 'chrcconsistgrp', and 'rmrcconsistgrp'
@@ -31,15 +31,14 @@ options:
         type: str
     state:
         description:
-            - Creates or updates (C(present)), removes (C(absent))
+            - Creates or updates (C(present)) removes (C(absent))
               a consistency group.
         choices: [ absent, present ]
         required: true
         type: str
     clustername:
         description:
-            - The hostname or management IP of the
-              Spectrum Virtualize storage system.
+            - The hostname or management IP of the Spectrum Virtualize storage system.
         type: str
         required: true
     domain:
@@ -60,7 +59,7 @@ options:
     token:
         description:
         - The authentication token to verify a user on the Spectrum Virtualize storage system.
-        - To generate a token, use ibm_svc_auth module.
+        - To generate a token, use the ibm_svc_auth module.
         type: str
         version_added: '1.5.0'
     log_path:
@@ -93,17 +92,14 @@ options:
         type: bool
     copytype:
         description:
-            - Specifies the mirror type of the remote copy. 'metro' means MetroMirror,
-              'global' means GlobalMirror.
-            - If not specified, a MetroMirror remote copy will
-              be created when creating a remote copy C(state=present).
+            - Specifies the mirror type of the remote copy. 'metro' means MetroMirror, 'global' means GlobalMirror.
+            - If not specified, a MetroMirror remote copy will be created when creating a remote copy C(state=present).
         type: str
         choices: [ 'metro', 'global' ]
     cyclingmode:
         description:
             - Specifies the behavior of Global Mirror for the relationship.
-            - Active-active relationships and relationships with cycling modes set to Multiple
-              must always be configured with change volumes.
+            - Active-active relationships and relationships with cycling modes set to Multiple must always be configured with change volumes.
             - Applies when C(state=present) and C(copytype=global).
         type: str
         choices: [ 'multi', 'none' ]

--- a/plugins/modules/ibm_svc_manage_sra.py
+++ b/plugins/modules/ibm_svc_manage_sra.py
@@ -1,0 +1,433 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_manage_sra
+short_description: This module manages remote support assistance configuration on IBM Spectrum Virtualize family storage systems
+version_added: "1.7.0"
+description:
+  - Ansible interface to manage 'chsra' support remote assistance command.
+options:
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the ibm_svc_auth module.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    state:
+        description:
+            - Enables (C(enabled)) or disables (C(disabled)) the remote support assistance.
+        choices: [ enabled, disabled ]
+        required: true
+        type: str
+    support:
+        description:
+            - Specifies the support assistance through C(remote) or C(onsite).
+        choices: [ remote, onsite ]
+        type: str
+        required: true
+    name:
+        description:
+            - Specifies the list of unique names for the support center or proxy to be defined.
+            - Required when C(support=remote), to enable remote support assistance.
+        type: list
+        elements: str
+    sra_ip:
+        description:
+            - Specifies the list of IP addresses or fully qualified domain names for the new support center or proxy server.
+            - Required when C(support=remote) and C(state=enabled), to enable support remote assistannce.
+        type: list
+        elements: str
+    sra_port:
+        description:
+            - Specifies the list of port numbers for the new support center or proxy server.
+            - Required when C(support=remote) and C(state=enabled), to enable support remote assistannce.
+        type: list
+        elements: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+author:
+    - Sanjaikumaar M (@sanjaikumaar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Using IBM Spectrum Virtualize collection to enable and disable remote support assistance.
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Get authorization token
+      register: result
+      ibm_svc_auth:
+        clustername: "{{ clustername }}"
+        domain: "{{ domain }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        log_path: "{{ log_path }}"
+    - name: Enable support remote assistance
+      ibm_svc_manage_sra:
+        clustername: "{{ clustername }}"
+        domain: "{{ domain }}"
+        token: "{{ result.token }}"
+        log_path: "{{ log_path }}"
+        support: remote
+        state: enabled
+        name:
+          - proxy_1
+          - proxy_2
+          - proxy_3
+        sra_ip:
+          - '0.0.0.0'
+          - '1.1.1.1'
+          - '2.1.2.2'
+        sra_port:
+          - 8888
+          - 9999
+          - 8800
+    - name: Disable support remote assistance
+      ibm_svc_manage_sra:
+        clustername: "{{ clustername }}"
+        domain: "{{ domain }}"
+        token: "{{ result.token }}"
+        log_path: "{{ log_path }}"
+        support: remote
+        state: disabled
+        name:
+          - proxy_1
+          - proxy_2
+          - proxy_3
+'''
+
+RETURN = '''
+'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import (
+    IBMSVCRestApi, svc_argument_spec,
+    get_logger
+)
+from ansible.module_utils._text import to_native
+
+
+class IBMSVCSupportRemoteAssistance:
+
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                state=dict(
+                    type='str',
+                    required=True,
+                    choices=['enabled', 'disabled']
+                ),
+                support=dict(
+                    type='str',
+                    required=True,
+                    choices=['remote', 'onsite']
+                ),
+                name=dict(type='list', elements='str'),
+                sra_ip=dict(type='list', elements='str'),
+                sra_port=dict(type='list', elements='str')
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # Required parameters
+        self.support = self.module.params['support']
+        self.state = self.module.params['state']
+
+        # Optional parameters
+        self.name = self.module.params.get('name', [])
+        self.sra_ip = self.module.params.get('sra_ip', [])
+        self.sra_port = self.module.params.get('sra_port', [])
+
+        self.basic_checks()
+
+        # Varialbe to store some frequently used data
+        self.sra_status_detail = None
+
+        # logging setup
+        self.log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, self.log_path)
+        self.log = log.info
+        self.changed = False
+        self.msg = ''
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=self.log_path,
+            token=self.module.params['token']
+        )
+
+    def basic_checks(self):
+        self.filtered_params = dict(
+            filter(
+                lambda item: item[0] in ['name', 'sra_ip', 'sra_port'],
+                self.module.params.items()
+            )
+        )
+        if self.support == 'remote' and self.state == 'enabled':
+            if self.name and self.sra_ip and self.sra_port:
+                if len(self.name) == len(self.sra_ip) == len(self.sra_port):
+                    if not all([all(self.name), all(self.sra_ip), all(self.sra_port)]):
+                        missing_params = ', '.join([k for k, v in self.filtered_params.items() if not all(v)])
+                        self.module.fail_json(
+                            msg='{0} should not contain blank values'.format(missing_params)
+                        )
+                else:
+                    self.module.fail_json(
+                        msg='Name, sra_ip and sra_port parameters should contain same number of arguments'
+                    )
+            else:
+                missing_params = ', '.join([k for k, v in self.filtered_params.items() if not v])
+                self.module.fail_json(
+                    msg='support is remote and state is enabled but following parameter missing: {0}'.format(missing_params)
+                )
+        elif self.support == 'remote' and self.state == 'disabled':
+            if self.sra_ip or self.sra_port:
+                invalid_params = ', '.join([k for k, v in self.filtered_params.items() if k in ['sra_ip', 'sra_port'] and v])
+                self.module.fail_json(
+                    msg='{0} should not be passed when support=remote and state=disabled'.format(invalid_params)
+                )
+        elif self.support == 'onsite':
+            if self.name or self.sra_ip or self.sra_port:
+                invalid_params = ', '.join([k for k, v in self.filtered_params.items()])
+                self.module.fail_json(
+                    msg='{0} should not be passed when support=onsite'.format(invalid_params)
+                )
+
+    def is_sra_enabled(self):
+        if self.sra_status_detail:
+            return self.sra_status_detail['status'] == 'enabled'
+
+        result = self.restapi.svc_obj_info(
+            cmd='lssra',
+            cmdopts=None,
+            cmdargs=None
+        )
+        self.sra_status_detail = result
+        return result['status'] == 'enabled'
+
+    def is_remote_support_enabled(self):
+        if self.sra_status_detail:
+            return self.sra_status_detail['remote_support_enabled'] == 'yes'
+
+        result = self.restapi.svc_obj_info(
+            cmd='lssra',
+            cmdopts=None,
+            cmdargs=None
+        )
+        return result['remote_support_enabled'] == 'yes'
+
+    def is_proxy_exist(self, obj_name):
+        obj = {}
+        result = self.restapi.svc_obj_info(
+            cmd='lssystemsupportcenter',
+            cmdopts=None,
+            cmdargs=[obj_name]
+        )
+
+        if isinstance(result, list):
+            for d in result:
+                obj.update(d)
+        else:
+            obj = result
+
+        return obj
+
+    def sra_probe(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        message = ''
+        if (self.support == 'remote' and not self.is_remote_support_enabled()) \
+                or (self.support == 'onsite' and self.is_remote_support_enabled()):
+
+            message += 'SRA configuration cannot be updated right now. '
+
+        if any(self.add_proxy_details()):
+            message += 'Proxy server details cannot be updated when SRA is enabled. '
+
+        message += 'Please disable SRA and try to update.' if message else ''
+
+        self.msg = message if message else self.msg
+
+        return self.msg
+
+    def add_proxy_details(self):
+        existed = []
+        if self.support == 'remote':
+            cmd = 'mksystemsupportcenter'
+            cmdargs = []
+
+            for nm, ip, port in zip(self.name, self.sra_ip, self.sra_port):
+                if nm != 'None' and ip != 'None' and port != 'None':
+                    if not self.is_proxy_exist(nm):
+                        existed.append(True)
+                        if not self.is_sra_enabled():
+                            cmdopts = {
+                                'name': nm,
+                                'ip': ip,
+                                'port': port,
+                                'proxy': 'yes'
+                            }
+                            self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+                            self.log('Proxy server(%s) details added', nm)
+                    else:
+                        self.log('Skipping, Proxy server(%s) already exist', nm)
+                else:
+                    missing_params = ', '.join([k for k, v in self.filtered_params.items() if 'None' in v])
+                    self.module.fail_json(
+                        msg='support is remote and state is enabled but following parameter missing: {0}'.format(missing_params)
+                    )
+
+        return existed
+
+    def remove_proxy_details(self):
+        if self.support == 'remote':
+            cmd = 'rmsystemsupportcenter'
+            cmdopts = {}
+
+            for nm in self.name:
+                if nm and nm != 'None':
+                    if self.is_proxy_exist(nm):
+                        cmdargs = [nm]
+                        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+                        self.log('Proxy server(%s) details removed', nm)
+                    else:
+                        self.log('Proxy server(%s) does not exist', nm)
+                else:
+                    self.module.fail_json(
+                        msg='support is remote and state is disabled but following parameter is blank: name'
+                    )
+
+    def enable_sra(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        self.add_proxy_details()
+
+        cmd = 'chsra'
+        cmdopts = {}
+        cmdargs = ['-enable']
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        if self.support == 'remote':
+            cmdargs = ['-remotesupport', 'enable']
+            self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        self.log('%s support assistance enabled', self.support.capitalize())
+
+        self.changed = True
+
+    def disable_sra(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'chsra'
+        cmdopts = {}
+
+        if self.support == 'remote':
+            cmdargs = ['-remotesupport', 'disable']
+            self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        cmdargs = ['-disable']
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+        self.log('%s support assistance disabled', self.support.capitalize())
+
+        self.remove_proxy_details()
+        self.changed = True
+
+    def apply(self):
+        if self.is_sra_enabled():
+            if self.state == 'enabled':
+                if not self.sra_probe():
+                    self.msg = 'Support remote assistance already enabled. '\
+                               'No modifications done.'
+            else:
+                self.disable_sra()
+                self.msg = 'Support remote assistance disabled.'
+        else:
+            if self.state == 'disabled':
+                self.msg = 'Support remote assistance is already disabled.'
+            else:
+                self.enable_sra()
+                self.msg = 'Support remote assistance({0}) enabled.'.format(
+                    self.support
+                )
+
+        if self.module.check_mode:
+            self.msg = 'skipping changes due to check mode.'
+
+        self.module.exit_json(msg=self.msg, changed=self.changed)
+
+
+def main():
+    v = IBMSVCSupportRemoteAssistance()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log('Exception in apply(): \n%s', format_exc())
+        v.module.fail_json(msg='Module failed. Error [%s].' % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_svc_manage_user.py
+++ b/plugins/modules/ibm_svc_manage_user.py
@@ -1,0 +1,405 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 IBM CORPORATION
+# Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_manage_user
+short_description: This module manages user on IBM Spectrum Virtualize family storage systems
+description:
+  - Ansible interface to manage 'mkuser', 'rmuser', and 'chuser' commands.
+version_added: "1.7.0"
+options:
+    name:
+        description:
+            - Specifies the unique username.
+        required: true
+        type: str
+    state:
+        description:
+            - Creates or updates (C(present)) or removes (C(absent)) a user.
+        choices: [ present, absent ]
+        required: true
+        type: str
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        type: str
+        required: true
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the ibm_svc_auth module.
+        type: str
+    user_password:
+        description:
+            - Specifies the password associated with the user.
+            - Applies when C(state=present).
+        type: str
+    nopassword:
+        description:
+            - Specifies that the user's password is to be deleted.
+            - Applies when C(state=present), to modify a user.
+        type: bool
+    keyfile:
+        description:
+            - Specifies the name of the file containing the Secure Shell (SSH) public key.
+            - Applies when C(state=present).
+        type: str
+    nokey:
+        description:
+            - Specifies that the user's SSH key is to be deleted.
+            - Applies when C(state=present), to modify a user.
+        type: bool
+    auth_type:
+        description:
+            - Specifies whether the user authenticates to the system using a remote authentication service or system authentication methods.
+            - Only supported value is 'usergrp'.
+            - Required when C(state=present), to create a user.
+        choices: [ usergrp ]
+        type: str
+    usergroup:
+        description:
+            - Specifies the name of the user group with which the local user is to be associated.
+            - Applies when C(state=present) and C(auth_type=usergrp).
+        type: str
+    forcepasswordchange:
+        description:
+            - Specifies that the password is to be changed on next login.
+            - Applies when C(state=present), to modify a user.
+        type: bool
+    lock:
+        description:
+            - Specifies to lock the account indefinitely. The user cannot log in unless unlocked again with the parameter I(unlock).
+            - Applies when C(state=present), to modify a user.
+            - Parameters I(lock) and I(unlock) are mutually exclusive.
+        type: bool
+    unlock:
+        description:
+            - Specifies to unlock the account so it can be logged in to again.
+            - Applies when C(state=present), to modify a user.
+            - Parameters I(lock) and I(unlock) are mutually exclusive.
+        type: bool
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+author:
+    - Sreshtant Bohidar(@Sreshtant-Bohidar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Using the IBM Spectrum Virtualize collection to create a user
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Create a user
+      ibm_svc_manage_user:
+        clustername: "{{clustername}}"
+        domain: "{{domain}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        log_path: /tmp/playbook.debug
+        state: present
+        name: user-name
+        user_password: user-password
+        auth_type: usergrp
+        usergroup: usergroup-name
+
+- name: Using the IBM Spectrum Virtualize collection to remove a user
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Remove a user
+      ibm_svc_manage_user:
+        clustername: "{{clustername}}"
+        domain: "{{domain}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        log_path: /tmp/playbook.debug
+        state: absent
+        name: user-name
+
+'''
+RETURN = '''
+'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec, get_logger
+from ansible.module_utils._text import to_native
+
+
+class IBMSVCUser(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                state=dict(type='str', required=True, choices=['present', 'absent']),
+                auth_type=dict(type='str', required=False, choices=['usergrp']),
+                user_password=dict(type='str', required=False, no_log=True),
+                nopassword=dict(type='bool', required=False),
+                keyfile=dict(type='str', required=False, no_log=True),
+                nokey=dict(type='bool', required=False),
+                forcepasswordchange=dict(type='bool', required=False),
+                lock=dict(type='bool', required=False),
+                unlock=dict(type='bool', required=False),
+                usergroup=dict(type='str', required=False),
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, log_path)
+        self.log = log.info
+
+        # Required
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Required during creation of user
+        self.auth_type = self.module.params['auth_type']
+        self.usergroup = self.module.params['usergroup']
+
+        # Optional
+        self.user_password = self.module.params.get('user_password', False)
+        self.nopassword = self.module.params.get('nopassword', False)
+        self.keyfile = self.module.params.get('keyfile', False)
+        self.nokey = self.module.params.get('nokey', False)
+        self.forcepasswordchange = self.module.params.get('forcepasswordchange', False)
+        self.lock = self.module.params.get('lock', False)
+        self.unlock = self.module.params.get('unlock', False)
+
+        # creating an instance of IBMSVCRestApi
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path,
+            token=self.module.params['token']
+        )
+
+    # perform some basic checks
+    def basic_checks(self):
+        # Handling for mandatory parameter name
+        if not self.name:
+            self.module.fail_json(msg="Missing mandatory parameter: name")
+        # Handling for mandatory parameter state
+        if not self.state:
+            self.module.fail_json(msg="Missing mandatory parameter: state")
+        # Handling mutually exclusive cases amoung parameters
+        if self.user_password and self.nopassword:
+            self.module.fail_json(msg="Mutually exclusive parameter: user_password, nopassword")
+        if self.lock and self.unlock:
+            self.module.fail_json(msg="Mutually exclusive parameter: lock, unlock")
+        if self.keyfile and self.nokey:
+            self.module.fail_json(msg="Mutually exclusive parameter: keyfile, nokey")
+        if self.auth_type == 'usergrp' and not self.usergroup:
+            self.module.fail_json(msg="Parameter [usergroup] is required when auth_type is usergrp")
+
+    # function to get user data
+    def get_existing_user(self):
+        merged_result = {}
+        data = self.restapi.svc_obj_info(cmd='lsuser', cmdopts=None, cmdargs=[self.name])
+        self.log('GET: user data: %s', data)
+        if isinstance(data, list):
+            for d in data:
+                merged_result.update(d)
+        else:
+            merged_result = data
+
+        return merged_result
+
+    # function for creating new user
+    def create_user(self):
+        # Handling unsupported parameter during user creation
+        if self.nokey or self.nopassword or self.lock or self.unlock or self.forcepasswordchange:
+            self.module.fail_json(msg="Parameters [nokey, nopassword, lock, unlock, forcepasswordchange] not applicable while creating a user")
+        # Handling for mandatory parameter role
+        if not self.auth_type:
+            self.module.fail_json(msg="Missing required parameter: auth_type")
+        if self.auth_type == 'usergrp' and not self.usergroup:
+            self.module.fail_json(msg="Missing required parameter: usergroup")
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'mkuser'
+        command_options = {
+            'name': self.name,
+        }
+        if self.user_password:
+            command_options['password'] = self.user_password
+        if self.keyfile:
+            command_options['keyfile'] = self.keyfile
+        if self.usergroup:
+            command_options['usergrp'] = self.usergroup
+        if self.forcepasswordchange:
+            command_options['forcepasswordchange'] = self.forcepasswordchange
+
+        result = self.restapi.svc_run_command(command, command_options, cmdargs=None)
+        self.log("create user result %s", result)
+        if 'message' in result:
+            self.changed = True
+            self.log("create user result message %s", result['message'])
+        else:
+            self.module.fail_json(
+                msg="Failed to create user [%s]" % self.name)
+
+    # function for probing an existing user
+    def probe_user(self, data):
+        properties = {}
+
+        if self.usergroup:
+            if self.usergroup != data['usergrp_name']:
+                properties['usergrp'] = self.usergroup
+        if self.user_password:
+            properties['password'] = self.user_password
+        if self.nopassword:
+            if data['password'] == 'yes':
+                properties['nopassword'] = True
+        if self.keyfile:
+            properties['keyfile'] = self.keyfile
+        if self.nokey:
+            if data['ssh_key'] == "yes":
+                properties['nokey'] = True
+        if self.lock:
+            properties['lock'] = True
+        if self.unlock:
+            properties['unlock'] = True
+        if self.forcepasswordchange:
+            properties['forcepasswordchange'] = True
+
+        return properties
+
+    # function for updating an existing user
+    def update_user(self, data):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        self.log("updating user '%s'", self.name)
+        command = 'chuser'
+        for parameter in data:
+            command_options = {
+                parameter: data[parameter]
+            }
+            self.restapi.svc_run_command(command, command_options, [self.name])
+        self.changed = True
+
+    # function for removing an existing user
+    def remove_user(self):
+        # Handling unsupported parameter during user removal
+        if self.nokey or self.nopassword or self.lock or self.unlock or self.forcepasswordchange:
+            self.module.fail_json(msg="Parameters [nokey, nopassword, lock, unlock, forcepasswordchange] not applicable while removing a user")
+        if self.module.check_mode:
+            self.changed = True
+            return
+        self.log("deleting user '%s'", self.name)
+        command = 'rmuser'
+        command_options = None
+        cmdargs = [self.name]
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.changed = True
+
+    def apply(self):
+        changed = False
+        msg = None
+        modify = {}
+        self.basic_checks()
+
+        user_data = self.get_existing_user()
+
+        if user_data:
+            if self.state == 'absent':
+                self.log("CHANGED: user exists, but requested state is 'absent'")
+                changed = True
+            elif self.state == 'present':
+                # initiate probing of an existing user
+                modify = self.probe_user(user_data)
+                if modify:
+                    self.log("CHANGED: user exists, but probe detected changes")
+                    changed = True
+        else:
+            if self.state == 'present':
+                self.log("CHANGED: user does not exist, but requested state is 'present'")
+                changed = True
+        if changed:
+            if self.state == 'present':
+                if not user_data:
+                    # initiate creation of new user
+                    self.create_user()
+                    msg = "User [%s] has been created." % self.name
+                else:
+                    # initiate updation os an existing user
+                    self.update_user(modify)
+                    msg = "User [%s] has been modified." % self.name
+            elif self.state == 'absent':
+                # initiate deletion of an existing user
+                self.remove_user()
+                msg = "User [%s] has been removed." % self.name
+            if self.module.check_mode:
+                msg = "Skipping changes due to check mode."
+        else:
+            if self.state == 'absent':
+                msg = "User [%s] does not exist." % self.name
+            elif self.state == 'present':
+                msg = "User [%s] already exist (no modificationes detected)." % self.name
+
+        self.module.exit_json(msg=msg, changed=changed)
+
+
+def main():
+    v = IBMSVCUser()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_svc_manage_usergroup.py
+++ b/plugins/modules/ibm_svc_manage_usergroup.py
@@ -1,0 +1,341 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 IBM CORPORATION
+# Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_manage_usergroup
+short_description: This module manages user group on IBM Spectrum Virtualize family storage systems
+description:
+  - Ansible interface to manage 'mkusergrp', 'rmusergrp', and 'chusergrp' commands.
+version_added: "1.7.0"
+options:
+    name:
+        description:
+            - Specifies the name of the user group.
+        required: true
+        type: str
+    state:
+        description:
+            - Creates or updates (C(present)) or removes (C(absent)) a user group.
+        choices: [ present, absent ]
+        required: true
+        type: str
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        type: str
+        required: true
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the ibm_svc_auth module.
+        type: str
+    role:
+        description:
+            - Specifies the role associated with all users that belong to this user group.
+            - Required when C(state=present).
+        choices: [ Monitor, CopyOperator, Service, FlashCopyAdmin, Administrator, SecurityAdmin, VasaProvider, RestrictedAdmin, 3SiteAdmin ]
+        type: str
+    ownershipgroup:
+        description:
+            - Specifies the name of the ownership group.
+            - Applies when C(state=present).
+            - Parameters I(ownershipgroup) and I(noownershipgroup) are mutually exclusive.
+        type: str
+    noownershipgroup:
+        description:
+            - Specifies that the usergroup is removed from the ownership group it belonged to.
+            - Applies when C(state=present), to modify a user group.
+            - Parameters I(ownershipgroup) and I(noownershipgroup) are mutually exclusive.
+        type: bool
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+author:
+    - Sreshtant Bohidar(@Sreshtant-Bohidar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Using the IBM Spectrum Virtualize collection to create a user group
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Create a user group
+      ibm_svc_manage_usergroup:
+        clustername: "{{clustername}}"
+        domain: "{{domain}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        log_path: /tmp/playbook.debug
+        state: present
+        name: user-group-name
+        role: Monitor
+        ownershipgroup: ownershipgroup-name
+
+- name: Using the IBM Spectrum Virtualize collection to remove a user group
+  hosts: localhost
+  collections:
+    - ibm.spectrum_virtualize
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Remove a user group
+      ibm_svc_manage_usergroup:
+        clustername: "{{clustername}}"
+        domain: "{{domain}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        log_path: /tmp/playbook.debug
+        state: absent
+        name: user-group-name
+
+'''
+RETURN = '''
+'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec, get_logger
+from ansible.module_utils._text import to_native
+
+
+class IBMSVCUsergroup(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                role=dict(type='str', required=False, choices=[
+                    'Monitor', 'CopyOperator', 'Service', 'FlashCopyAdmin',
+                    'Administrator', 'SecurityAdmin', 'VasaProvider',
+                    'RestrictedAdmin', '3SiteAdmin'
+                ]),
+                ownershipgroup=dict(type='str', required=False),
+                noownershipgroup=dict(type='bool', required=False),
+                state=dict(type='str', required=True, choices=['present', 'absent'])
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, log_path)
+        self.log = log.info
+
+        # Required
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Required during creation of user group
+        self.role = self.module.params['role']
+
+        # Optional
+        self.ownershipgroup = self.module.params.get('ownershipgroup', False)
+        self.noownershipgroup = self.module.params.get('noownershipgroup', False)
+
+        # creating an instance of IBMSVCRestApi
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path,
+            token=self.module.params['token']
+        )
+
+    # perform some basic checks
+    def basic_checks(self):
+        # Handling for mandatory parameter name
+        if not self.name:
+            self.module.fail_json(msg="Missing mandatory parameter: name")
+        # Handling for mandatory parameter state
+        if not self.state:
+            self.module.fail_json(msg="Missing mandatory parameter: state")
+        # Handing mutually exclusive cases
+        if self.ownershipgroup and self.noownershipgroup:
+            self.module.fail_json(msg="Mutually exclusive parameter: ownershipgroup, noownershipgroup")
+        # Handling unsupported parameter while removing an usergroup
+        if self.state == 'absent' and (self.role or self.ownershipgroup or self.noownershipgroup):
+            self.module.fail_json(msg="Parameters [role, ownershipgroup, noownershipgroup] are not applicable while removing a usergroup")
+
+    # function to get user group data
+    def get_existing_usergroup(self):
+        merged_result = {}
+        data = self.restapi.svc_obj_info(cmd='lsusergrp', cmdopts=None, cmdargs=[self.name])
+        self.log('GET: user group data: %s', data)
+        if isinstance(data, list):
+            for d in data:
+                merged_result.update(d)
+        else:
+            merged_result = data
+
+        return merged_result
+
+    # function for creating new user group
+    def create_user_group(self):
+        # Handling unsupported parameter during usergroup creation
+        if self.noownershipgroup:
+            self.module.fail_json(msg="Parameter [noownershipgroup] is not applicable while creating a usergroup")
+        # Handling for mandatory parameter role
+        if not self.role:
+            self.module.fail_json(msg="Missing mandatory parameter: role")
+        if self.module.check_mode:
+            self.changed = True
+            return
+        command = 'mkusergrp'
+        command_options = {
+            'name': self.name,
+        }
+        if self.role:
+            command_options['role'] = self.role
+        if self.ownershipgroup:
+            command_options['ownershipgroup'] = self.ownershipgroup
+        result = self.restapi.svc_run_command(command, command_options, cmdargs=None)
+        self.log("create user group result %s", result)
+        if 'message' in result:
+            self.changed = True
+            self.log("create user group result message %s", result['message'])
+        else:
+            self.module.fail_json(
+                msg="Failed to user volume group [%s]" % self.name)
+
+    # function for probing an existing user group
+    def probe_user_group(self, data):
+        properties = {}
+        if self.role:
+            if self.role != data['role']:
+                properties['role'] = self.role
+        if self.ownershipgroup:
+            if self.ownershipgroup != data['owner_name']:
+                properties['ownershipgroup'] = self.ownershipgroup
+        if self.noownershipgroup:
+            if data['owner_name']:
+                properties['noownershipgroup'] = True
+        return properties
+
+    # function for updating an existing user group
+    def update_user_group(self, data):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        self.log("updating user group '%s'", self.name)
+        command = 'chusergrp'
+        command_options = {}
+        if 'role' in data:
+            command_options['role'] = data['role']
+        if 'ownershipgroup' in data:
+            command_options['ownershipgroup'] = data['ownershipgroup']
+        if 'noownershipgroup' in data:
+            command_options['noownershipgroup'] = True
+        cmdargs = [self.name]
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.changed = True
+
+    # function for removing an existing user group
+    def remove_user_group(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+        self.log("deleting user group '%s'", self.name)
+        command = 'rmusergrp'
+        command_options = None
+        cmdargs = [self.name]
+        self.restapi.svc_run_command(command, command_options, cmdargs)
+        self.changed = True
+
+    def apply(self):
+        changed = False
+        msg = None
+        modify = {}
+        self.basic_checks()
+
+        user_group_data = self.get_existing_usergroup()
+
+        if user_group_data:
+            if self.state == 'absent':
+                self.log("CHANGED: user group exists, but requested state is 'absent'")
+                changed = True
+            elif self.state == 'present':
+                # initiate probing
+                modify = self.probe_user_group(user_group_data)
+                if modify:
+                    self.log("CHANGED: user group exists, but probe detected changes")
+                    changed = True
+        else:
+            if self.state == 'present':
+                self.log("CHANGED: user group does not exist, but requested state is 'present'")
+                changed = True
+        if changed:
+            if self.state == 'present':
+                if not user_group_data:
+                    self.create_user_group()
+                    msg = "User group [%s] has been created." % self.name
+                else:
+                    self.update_user_group(modify)
+                    msg = "User group [%s] has been modified." % self.name
+            elif self.state == 'absent':
+                self.remove_user_group()
+                msg = "User group [%s] has been removed." % self.name
+            if self.module.check_mode:
+                msg = "Skipping changes due to check mode."
+        else:
+            if self.state == 'absent':
+                msg = "User group [%s] does not exist." % self.name
+            elif self.state == 'present':
+                msg = "User group [%s] already exist (no modificationes detected)." % self.name
+
+        self.module.exit_json(msg=msg, changed=changed)
+
+
+def main():
+    v = IBMSVCUsergroup()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_svc_manage_volume.py
+++ b/plugins/modules/ibm_svc_manage_volume.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -15,8 +15,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_volume
-short_description: This module manages standard volumes on IBM Spectrum Virtualize
-                   Family storage systems
+short_description: This module manages standard volumes on IBM Spectrum Virtualize family storage systems
 description:
   - Ansible interface to manage 'mkvolume', 'rmvolume', and 'chvdisk' volume commands.
 version_added: "1.6.0"
@@ -28,7 +27,7 @@ options:
     type: str
   state:
     description:
-      - Creates or updates (C(present)), or removes (C(absent)), a volume.
+      - Creates or updates (C(present)) or removes (C(absent)) a volume.
     choices: [ absent, present ]
     required: true
     type: str
@@ -55,7 +54,7 @@ options:
   token:
     description:
       - The authentication token to verify a user on the Spectrum Virtualize storage system.
-      - To generate a token, use ibm_svc_auth module.
+      - To generate a token, use the ibm_svc_auth module.
     type: str
   pool:
     description:

--- a/plugins/modules/ibm_svc_manage_volumegroup.py
+++ b/plugins/modules/ibm_svc_manage_volumegroup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -17,8 +17,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_manage_volumegroup
-short_description: This module manages volume groups on
-                   IBM Spectrum Virtualize Family storage systems
+short_description: This module manages volume groups on IBM Spectrum Virtualize family storage systems
 version_added: "1.6.0"
 description:
   - Ansible interface to manage 'mkvolumegroup', 'chvolumegroup', and 'rmvolumegroup'
@@ -31,8 +30,7 @@ options:
         type: str
     state:
         description:
-            - Creates or updates (C(present)), or removes (C(absent)),
-              a volume group.
+            - Creates or updates (C(present)) or removes (C(absent)) a volume group.
         choices: [ absent, present ]
         required: true
         type: str
@@ -59,7 +57,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use ibm_svc_auth module.
+            - To generate a token, use the ibm_svc_auth module.
         type: str
     log_path:
         description:

--- a/plugins/modules/ibm_svc_mdisk.py
+++ b/plugins/modules/ibm_svc_mdisk.py
@@ -14,8 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: ibm_svc_mdisk
-short_description: This module manages MDisks on IBM Spectrum Virtualize
-                   Family storage systems
+short_description: This module manages MDisks on IBM Spectrum Virtualize family storage systems
 description:
   - Ansible interface to manage 'mkarray' and 'rmmdisk' MDisk commands.
 version_added: "1.0.0"
@@ -54,7 +53,7 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
     version_added: '1.5.0'
   drive:

--- a/plugins/modules/ibm_svc_mdiskgrp.py
+++ b/plugins/modules/ibm_svc_mdiskgrp.py
@@ -14,8 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: ibm_svc_mdiskgrp
-short_description: This module manages pools on IBM Spectrum Virtualize
-                   Family storage systems
+short_description: This module manages pools on IBM Spectrum Virtualize family storage systems
 description:
   - Ansible interface to manage 'mkmdiskgrp' and 'rmmdiskgrp' pool commands.
 version_added: "1.0.0"
@@ -54,7 +53,7 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
     version_added: '1.5.0'
   datareduction:

--- a/plugins/modules/ibm_svc_start_stop_flashcopy.py
+++ b/plugins/modules/ibm_svc_start_stop_flashcopy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2020 IBM CORPORATION
+# Copyright (C) 2021 IBM CORPORATION
 # Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -16,8 +16,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_start_stop_flashcopy
-short_description: This module starts or stops FlashCopy mapping and consistency groups
-                   on IBM Spectrum Virtualize Family storage systems
+short_description: This module starts or stops FlashCopy mapping and consistency groups on IBM Spectrum Virtualize family storage systems
 description:
   - Ansible interface to manage 'startfcmap', 'stopfcmap', 'startfcconsistgrp', and 'stopfcconsistgrp' commands.
 version_added: "1.4.0"
@@ -29,7 +28,7 @@ options:
         type: str
     state:
         description:
-            - Starts (C(started)), stops (C(stopped)) a FlashCopy mapping or FlashCopy consistency group.
+            - Starts (C(started)) or stops (C(stopped)) a FlashCopy mapping or FlashCopy consistency group.
         choices: [ started, stopped ]
         required: true
         type: str
@@ -56,7 +55,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use ibm_svc_auth module.
+            - To generate a token, use the ibm_svc_auth module.
         type: str
         version_added: '1.5.0'
     isgroup:
@@ -67,8 +66,7 @@ options:
         type: bool
     force:
         description:
-            - Specifies that all processing associated with the FlashCopy mapping
-              or FlashCopy consistency group be immediately stopped.
+            - Specifies that all processing associated with the FlashCopy mapping or FlashCopy consistency group be immediately stopped.
             - Valid when C(state=stopped), to stop a FlashCopy mapping or FlashCopy consistency group.
         required: false
         type: bool
@@ -235,7 +233,7 @@ class IBMSVCFlashcopyStartStop(object):
         if self.force:
             cmdopts["force"] = self.force
         self.log("Starting fc mapping.. Command %s opts %s", cmd, cmdopts)
-        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.name])
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.name])
 
     def stop_fc(self):
         cmd = ''
@@ -247,12 +245,11 @@ class IBMSVCFlashcopyStartStop(object):
         if self.force:
             cmdopts["force"] = self.force
         self.log("Stopping fc mapping.. Command %s opts %s", cmd, cmdopts)
-        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.name])
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.name])
 
     def apply(self):
         changed = False
         msg = None
-        modify = []
         fcdata = self.get_existing_fcmapping()
         if fcdata:
             if self.state == "started" and fcdata["start_time"] == "":

--- a/plugins/modules/ibm_svc_start_stop_replication.py
+++ b/plugins/modules/ibm_svc_start_stop_replication.py
@@ -16,8 +16,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_start_stop_replication
-short_description: This module starts or stops remote copies on
-                   IBM Spectrum Virtualize Family storage systems
+short_description: This module starts or stops remote copies on IBM Spectrum Virtualize family storage systems
 version_added: "1.3.0"
 
 description:
@@ -26,13 +25,11 @@ description:
 options:
   name:
     description:
-      - Specifies a name to assign to the new remote copy relationship or group,
-        or to operate on the existing remote copy.
+      - Specifies a name to assign to the new remote copy relationship or group, or to operate on the existing remote copy.
     type: str
   state:
     description:
-      - Starts (C(started)), stops (C(stopped)) a
-        remote copy relationship.
+      - Starts (C(started)) or stops (C(stopped)) a remote copy relationship.
     choices: [started, stopped]
     required: true
     type: str
@@ -59,13 +56,12 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
     version_added: '1.5.0'
   primary:
     description:
-    - Specifies the copy direction by defining which disk
-      becomes the primary (source).
+    - Specifies the copy direction by defining which disk becomes the primary (source).
     - Applies when C(state=started).
     type: str
     choices: [ 'master', 'aux' ]
@@ -88,8 +84,7 @@ options:
     type: bool
   force:
     description:
-    - Specifies that the system must process the copy operation even if it
-      causes a temporary loss of consistency during synchronization.
+    - Specifies that the system must process the copy operation even if it causes a temporary loss of consistency during synchronization.
     - Applies when C(state=started).
     type: bool
   validate_certs:

--- a/plugins/modules/ibm_svc_vol_map.py
+++ b/plugins/modules/ibm_svc_vol_map.py
@@ -17,8 +17,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: ibm_svc_vol_map
-short_description: This module manages volume mapping on IBM Spectrum
-                   Virtualize Family storage systems
+short_description: This module manages volume mapping on IBM Spectrum Virtualize family storage systems
 description:
   - Ansible interface to manage volume mapping commands
     'mkvdiskhostmap', 'rmvdiskhostmap', 'mkvolumehostclustermap', and 'rmvolumehostclustermap'.
@@ -73,7 +72,7 @@ options:
   token:
     description:
     - The authentication token to verify a user on the Spectrum Virtualize storage system.
-    - To generate a token, use ibm_svc_auth module.
+    - To generate a token, use the ibm_svc_auth module.
     type: str
     version_added: '1.5.0'
   log_path:

--- a/plugins/modules/ibm_svcinfo_command.py
+++ b/plugins/modules/ibm_svcinfo_command.py
@@ -16,10 +16,10 @@ DOCUMENTATION = '''
 ---
 module: ibm_svcinfo_command
 short_description: This module implements SSH Client which helps to run
-                   svcinfo CLI command on IBM Spectrum Virtualize Family storage systems
+                   svcinfo CLI command on IBM Spectrum Virtualize family storage systems
 version_added: "1.2.0"
 description:
-- Runs single svcinfo CLI command on IBM Spectrum Virtualize Family storage systems.
+- Runs single svcinfo CLI command on IBM Spectrum Virtualize family storage systems.
   Filter options like filtervalue or pipe '|' with grep, awk, and others are
   not supported in the command in this module.
   Paramiko must be installed to use this module.

--- a/plugins/modules/ibm_svctask_command.py
+++ b/plugins/modules/ibm_svctask_command.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
 ---
 module: ibm_svctask_command
 short_description: This module implements SSH Client which helps to run
-                   svctask CLI command(s) on IBM Spectrum Virtualize Family storage systems
+                   svctask CLI command(s) on IBM Spectrum Virtualize family storage systems
 version_added: "1.2.0"
 description:
 - Runs svctask CLI command(s) on IBM Spectrum Virtualize Family storage systems.
@@ -28,7 +28,7 @@ options:
   command:
     description:
     - A list containing svctask CLI commands to be executed on storage.
-      Each command must start with svctask keyword.
+    - Each command must start with 'svctask' keyword.
     type: list
     elements: str
   usesshkey:
@@ -45,8 +45,7 @@ options:
     type: str
   clustername:
     description:
-    - The hostname or management IP of the
-      Spectrum Virtualize storage system.
+    - The hostname or management IP of the Spectrum Virtualize storage system.
     type: str
     required: true
   username:

--- a/tests/unit/plugins/modules/test_ibm_svc_initial_setup.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_initial_setup.py
@@ -1,0 +1,639 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_svc_initial_setup """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_svc_initial_setup import IBMSVCInitialSetup
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVCInitialSetup(unittest.TestCase):
+    """ a group of related Unit Tests"""
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.license_probe')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    def test_module_with_no_input_params(self,
+                                         run_cmd_mock,
+                                         system_info_mock,
+                                         license_probe_mock,
+                                         dns_info_mock,
+                                         auth_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+        })
+
+        license_probe_mock.return_value = []
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_module_fail_with_mutually_exclusive_param(self, auth_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'time': '101009142021',
+            'ntpip': '9.9.9.9'
+        })
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleFailJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_module_dns_validation_1(self, auth_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'dnsip': ['9.9.9.9']
+        })
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleFailJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_module_dns_validation_2(self, auth_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'dnsip': ['9.9.9.9'],
+            'dnsname': []
+        })
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleFailJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.license_probe')
+    def test_module_system_and_dns(self,
+                                   license_probe_mock,
+                                   auth_mock,
+                                   system_info_mock,
+                                   run_cmd_mock,
+                                   dns_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'system_name': 'cluster_test_0',
+            'time': '101009142021',
+            'timezone': 200,
+            'dnsname': ['test_dns'],
+            'dnsip': ['1.1.1.1']
+        })
+
+        system_info_mock.return_value = {
+            "id": "0000010023806192",
+            "name": "",
+            "location": "local",
+            "cluster_locale": "en_US",
+            "time_zone": "200 Asia/Calcutta",
+            "cluster_ntp_IP_address": "",
+        }
+
+        license_probe_mock.return_value = []
+
+        dns_info_mock.return_value = [
+            {
+                "id": "0",
+                "name": "h",
+                "type": "ipv4",
+                "IP_address": "9.20.136.11",
+                "status": "active"
+            },
+            {
+                "id": "1",
+                "name": "i",
+                "type": "ipv4",
+                "IP_address": "9.20.136.25",
+                "status": "active"
+            }
+        ]
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.license_probe')
+    def test_with_already_existed_system_and_dns(
+            self,
+            license_probe_mock,
+            auth_mock,
+            system_info_mock,
+            run_cmd_mock,
+            dns_info_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'system_name': 'cluster_test_0',
+            'ntpip': '9.9.9.9',
+            'timezone': 200,
+            'dnsname': ['test_dns'],
+            'dnsip': ['1.1.1.1']
+        })
+
+        system_info_mock.return_value = {
+            "id": "0000010023806192",
+            "name": "cluster_test_0",
+            "location": "local",
+            "cluster_locale": "en_US",
+            "time_zone": "200 Asia/Calcutta",
+            "cluster_ntp_IP_address": "9.9.9.9",
+        }
+
+        license_probe_mock.return_value = []
+
+        dns_info_mock.return_value = [
+            {
+                "id": "0",
+                "name": "test_dns",
+                "type": "ipv4",
+                "IP_address": "1.1.1.1",
+                "status": "active"
+            }
+        ]
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.license_probe')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_module_license_key_update(self,
+                                       auth_mock,
+                                       system_info_mock,
+                                       run_cmd_mock,
+                                       license_probe_mock,
+                                       dns_info_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'license_key': ['0123-4567-89AB-CDEF']
+        })
+
+        license_probe_mock.return_value = []
+
+        run_cmd_mock.return_value = [
+            {
+                "id": "0",
+                "name": "encryption",
+                "state": "inactive",
+                "license_key": "",
+                "trial_expiration_date": "",
+                "serial_num": "",
+                "mtm": ""
+            }
+        ]
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.license_probe')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_with_existing_license_key_update(self,
+                                              auth_mock,
+                                              system_info_mock,
+                                              run_cmd_mock,
+                                              license_probe_mock,
+                                              dns_info_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'license_key': ['0123-4567-89AB-CDEF']
+        })
+
+        license_probe_mock.return_value = []
+
+        run_cmd_mock.return_value = [
+            {
+                "id": "0",
+                "name": "encryption",
+                "state": "inactive",
+                "license_key": "0123-4567-89AB-CDEF",
+                "trial_expiration_date": "",
+                "serial_num": "",
+                "mtm": ""
+            }
+        ]
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.license_probe')
+    def test_module_empty_timezone(self,
+                                   license_probe_mock,
+                                   auth_mock,
+                                   system_info_mock,
+                                   run_cmd_mock,
+                                   dns_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'system_name': 'cluster_test_0',
+            'time': '101009142021',
+            'timezone': 200,
+        })
+
+        system_info_mock.return_value = {
+            "id": "0000010023806192",
+            "name": "",
+            "location": "local",
+            "cluster_locale": "en_US",
+            "time_zone": "",
+            "cluster_ntp_IP_address": "",
+        }
+
+        license_probe_mock.return_value = []
+
+        dns_info_mock.return_value = []
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_license_update_storwize(self,
+                                     auth_mock,
+                                     system_info_mock,
+                                     run_cmd_mock,
+                                     dns_info_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'remote': 5,
+            'virtualization': 1,
+            'flash': 1,
+            'compression': 4,
+            'cloud': 1,
+            'easytier': 1,
+            'physical_flash': True,
+            'encryption': True
+        })
+
+        system_info_mock.return_value = {
+            "id": "0000010023806192",
+            "name": "cluster_test_0",
+            "location": "local",
+            "cluster_locale": "en_US",
+            "time_zone": "200 Asia/Calcutta",
+            "cluster_ntp_IP_address": "9.9.9.9",
+            "product_name": "IBM Storwize V7000"
+        }
+
+        run_cmd_mock.return_value = {
+            "license_flash": "0",
+            "license_remote": "4",
+            "license_virtualization": "0",
+            "license_physical_disks": "0",
+            "license_physical_flash": "off",
+            "license_physical_remote": "off",
+            "license_compression_capacity": "4",
+            "license_compression_enclosures": "5",
+            "license_easy_tier": "0",
+            "license_cloud_enclosures": "0"
+        }
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_existing_license_storwize(self,
+                                              auth_mock,
+                                              system_info_mock,
+                                              run_cmd_mock,
+                                              dns_info_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'remote': 5,
+            'virtualization': 1,
+            'flash': 0,
+            'compression': 4,
+            'cloud': 0,
+            'easytier': 0,
+            'physical_flash': "off",
+            'encryption': True
+        })
+
+        system_info_mock.return_value = {
+            "id": "0000010023806192",
+            "name": "cluster_test_0",
+            "location": "local",
+            "cluster_locale": "en_US",
+            "time_zone": "200 Asia/Calcutta",
+            "cluster_ntp_IP_address": "9.9.9.9",
+            "product_name": "IBM Storwize V7000"
+        }
+
+        run_cmd_mock.return_value = {
+            "license_flash": "0",
+            "license_remote": "5",
+            "license_virtualization": "1",
+            "license_physical_disks": "0",
+            "license_physical_flash": "off",
+            "license_physical_remote": "off",
+            "license_compression_capacity": "0",
+            "license_compression_enclosures": "4",
+            "license_easy_tier": "0",
+            "license_cloud_enclosures": "0"
+        }
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_license_update_with_SVC(self,
+                                     auth_mock,
+                                     system_info_mock,
+                                     run_cmd_mock,
+                                     dns_info_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'remote': 5,
+            'virtualization': 1,
+            'flash': 1,
+            'compression': 4,
+            'cloud': 1,
+            'easytier': 1,
+            'physical_flash': True,
+            'encryption': True
+        })
+
+        system_info_mock.return_value = {
+            "id": "0000010023806192",
+            "name": "cluster_test_0",
+            "location": "local",
+            "cluster_locale": "en_US",
+            "time_zone": "200 Asia/Calcutta",
+            "cluster_ntp_IP_address": "9.9.9.9",
+            "product_name": "SVC"
+        }
+
+        run_cmd_mock.return_value = {
+            "license_flash": "0",
+            "license_remote": "4",
+            "license_virtualization": "0",
+            "license_physical_disks": "0",
+            "license_physical_flash": "off",
+            "license_physical_remote": "off",
+            "license_compression_capacity": "0",
+            "license_compression_enclosures": "4",
+            "license_easy_tier": "0",
+            "license_cloud_enclosures": "0"
+        }
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_existing_dnsservers')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_initial_setup.IBMSVCInitialSetup.get_system_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_license_update_existing_SVC(self,
+                                         auth_mock,
+                                         system_info_mock,
+                                         run_cmd_mock,
+                                         dns_info_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'remote': 5,
+            'virtualization': 1,
+            'flash': 1,
+            'compression': 4,
+            'cloud': 1,
+            'easytier': 1,
+            'physical_flash': "on",
+            'encryption': True
+        })
+
+        system_info_mock.return_value = {
+            "id": "0000010023806192",
+            "name": "cluster_test_0",
+            "location": "local",
+            "cluster_locale": "en_US",
+            "time_zone": "200 Asia/Calcutta",
+            "cluster_ntp_IP_address": "9.9.9.9",
+            "product_name": "SVC"
+        }
+
+        run_cmd_mock.return_value = {
+            "license_flash": "1",
+            "license_remote": "5",
+            "license_virtualization": "1",
+            "license_physical_disks": "0",
+            "license_physical_flash": "on",
+            "license_physical_remote": "off",
+            "license_compression_capacity": "4",
+            "license_compression_enclosures": "5",
+            "license_easy_tier": "1",
+            "license_cloud_enclosures": "1"
+        }
+
+        svc_is = IBMSVCInitialSetup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            svc_is.apply()
+
+        self.assertFalse(exc.value.args[0]['changed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_callhome.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_callhome.py
@@ -1,0 +1,847 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_svc_manage_callhome """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_svc_manage_callhome import IBMSVCCallhome
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVCCallhome(unittest.TestCase):
+    """ a group of related Unit Tests"""
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def set_default_args(self):
+        return dict({
+            'name': 'test',
+            'state': 'enabled'
+        })
+
+    def test_module_fail_when_required_args_missing(self):
+        """ required arguments are reported as errors """
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({})
+            IBMSVCCallhome()
+        print('Info: %s' % exc.value.args[0]['msg'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_basic_checks(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        ch = IBMSVCCallhome()
+        data = ch.basic_checks()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_get_system_data(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_soi.return_value = {
+            "id": "0000010023806192",
+            "name": "Cluster_9.71.42.198",
+            "location": "local",
+            "partnership": "",
+            "total_mdisk_capacity": "3.6TB",
+            "space_in_mdisk_grps": "3.6TB",
+            "space_allocated_to_vdisks": "449.70GB",
+            "total_free_space": "3.2TB",
+            "total_vdiskcopy_capacity": "993.00GB",
+            "total_used_capacity": "435.67GB",
+            "total_overallocation": "26",
+            "total_vdisk_capacity": "993.00GB",
+            "total_allocated_extent_capacity": "455.00GB",
+            "statistics_status": "on",
+            "statistics_frequency": "15",
+            "cluster_locale": "en_US",
+            "time_zone": "503 SystemV/PST8",
+            "code_level": "8.4.2.0 (build 154.20.2109031944000)",
+            "console_IP": "9.71.42.198:443",
+            "id_alias": "0000010023806192",
+            "gm_link_tolerance": "300",
+            "gm_inter_cluster_delay_simulation": "0",
+            "gm_intra_cluster_delay_simulation": "0",
+            "gm_max_host_delay": "5",
+            "email_reply": "sreshtant.bohidar@ibm.com",
+            "email_contact": "Sreshtant Bohidar",
+            "email_contact_primary": "9439394132",
+            "email_contact_alternate": "9439394132",
+            "email_contact_location": "floor 2",
+            "email_contact2": "",
+            "email_contact2_primary": "",
+            "email_contact2_alternate": "",
+            "email_state": "stopped",
+            "inventory_mail_interval": "1",
+            "cluster_ntp_IP_address": "2.2.2.2",
+            "cluster_isns_IP_address": "",
+            "iscsi_auth_method": "none",
+            "iscsi_chap_secret": "",
+            "auth_service_configured": "no",
+            "auth_service_enabled": "no",
+            "auth_service_url": "",
+            "auth_service_user_name": "",
+            "auth_service_pwd_set": "no",
+            "auth_service_cert_set": "no",
+            "auth_service_type": "ldap",
+            "relationship_bandwidth_limit": "25",
+            "tiers": [
+                {
+                    "tier": "tier_scm",
+                    "tier_capacity": "0.00MB",
+                    "tier_free_capacity": "0.00MB"
+                },
+                {
+                    "tier": "tier0_flash",
+                    "tier_capacity": "1.78TB",
+                    "tier_free_capacity": "1.47TB"
+                },
+                {
+                    "tier": "tier1_flash",
+                    "tier_capacity": "0.00MB",
+                    "tier_free_capacity": "0.00MB"
+                },
+                {
+                    "tier": "tier_enterprise",
+                    "tier_capacity": "0.00MB",
+                    "tier_free_capacity": "0.00MB"
+                },
+                {
+                    "tier": "tier_nearline",
+                    "tier_capacity": "1.82TB",
+                    "tier_free_capacity": "1.68TB"
+                }
+            ],
+            "easy_tier_acceleration": "off",
+            "has_nas_key": "no",
+            "layer": "storage",
+            "rc_buffer_size": "256",
+            "compression_active": "no",
+            "compression_virtual_capacity": "0.00MB",
+            "compression_compressed_capacity": "0.00MB",
+            "compression_uncompressed_capacity": "0.00MB",
+            "cache_prefetch": "on",
+            "email_organization": "IBM",
+            "email_machine_address": "Street 39",
+            "email_machine_city": "New York",
+            "email_machine_state": "CAN",
+            "email_machine_zip": "123456",
+            "email_machine_country": "US",
+            "total_drive_raw_capacity": "10.10TB",
+            "compression_destage_mode": "off",
+            "local_fc_port_mask": "1111111111111111111111111111111111111111111111111111111111111111",
+            "partner_fc_port_mask": "1111111111111111111111111111111111111111111111111111111111111111",
+            "high_temp_mode": "off",
+            "topology": "hyperswap",
+            "topology_status": "dual_site",
+            "rc_auth_method": "none",
+            "vdisk_protection_time": "15",
+            "vdisk_protection_enabled": "no",
+            "product_name": "IBM Storwize V7000",
+            "odx": "off",
+            "max_replication_delay": "0",
+            "partnership_exclusion_threshold": "315",
+            "gen1_compatibility_mode_enabled": "no",
+            "ibm_customer": "262727272",
+            "ibm_component": "",
+            "ibm_country": "383",
+            "tier_scm_compressed_data_used": "0.00MB",
+            "tier0_flash_compressed_data_used": "0.00MB",
+            "tier1_flash_compressed_data_used": "0.00MB",
+            "tier_enterprise_compressed_data_used": "0.00MB",
+            "tier_nearline_compressed_data_used": "0.00MB",
+            "total_reclaimable_capacity": "380.13MB",
+            "physical_capacity": "3.60TB",
+            "physical_free_capacity": "3.15TB",
+            "used_capacity_before_reduction": "361.81MB",
+            "used_capacity_after_reduction": "14.27GB",
+            "overhead_capacity": "34.00GB",
+            "deduplication_capacity_saving": "0.00MB",
+            "enhanced_callhome": "on",
+            "censor_callhome": "on",
+            "host_unmap": "off",
+            "backend_unmap": "on",
+            "quorum_mode": "standard",
+            "quorum_site_id": "",
+            "quorum_site_name": "",
+            "quorum_lease": "short",
+            "automatic_vdisk_analysis_enabled": "on",
+            "callhome_accepted_usage": "no",
+            "safeguarded_copy_suspended": "no",
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        }
+        ch = IBMSVCCallhome()
+        data = ch.get_system_data()
+        self.assertEqual(data['callhome_accepted_usage'], 'no')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_get_existing_email_user_data(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_soi.return_value = [
+            {
+                "id": "0",
+                "name": "emailuser0",
+                "address": "callhome1@de.ibm.com",
+                "user_type": "support",
+                "error": "on",
+                "warning": "off",
+                "info": "off",
+                "inventory": "on"
+            },
+            {
+                "id": "1",
+                "name": "emailuser1",
+                "address": "test@domain.com",
+                "user_type": "local",
+                "error": "off",
+                "warning": "off",
+                "info": "off",
+                "inventory": "off"
+            }
+        ]
+        ch = IBMSVCCallhome()
+        data = ch.get_existing_email_user_data()
+        self.assertEqual(data['address'], 'test@domain.com')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_check_email_server_exists(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_soi.return_value = [
+            {
+                "id": "0",
+                "name": "emailserver0",
+                "IP_address": "9.20.118.16",
+                "port": "25",
+                "status": "active"
+            }
+        ]
+        ch = IBMSVCCallhome()
+        data = ch.check_email_server_exists()
+        self.assertEqual(data, True)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_check_email_user_exists(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_soi.return_value = [
+            {
+                "id": "0",
+                "name": "emailuser0",
+                "address": "test@domain.com",
+                "user_type": "support",
+                "error": "on",
+                "warning": "off",
+                "info": "off",
+                "inventory": "off"
+            }
+        ]
+        ch = IBMSVCCallhome()
+        data = ch.check_email_user_exists()
+        self.assertEqual(data['id'], '0')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_email_server(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_src.return_value = {
+            'id': '0',
+            'message': 'Email Server id [0] successfully created'
+        }
+        ch = IBMSVCCallhome()
+        data = ch.create_email_server()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_email_user(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_src.return_value = {
+            'id': '0',
+            'message': 'User, id [0], successfully created'
+        }
+        ch = IBMSVCCallhome()
+        data = ch.create_email_user()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_enable_email_callhome(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.enable_email_callhome()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_disable_email_callhome(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'disabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.disable_email_callhome()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_email_data(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'disabled',
+            'callhome_type': 'email',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25
+        })
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.update_email_data()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_get_existing_proxy(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'disabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'open_proxy'
+        })
+        mock_soi.return_value = {
+            "enabled": "yes",
+            "url": "http://h-proxy3.ssd.hursley.ibm.com",
+            "port": "3128",
+            "username": "",
+            "password_set": "no",
+            "certificate": "0 fields"
+        }
+        ch = IBMSVCCallhome()
+        data = ch.get_existing_proxy()
+        self.assertEqual(data['port'], '3128')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_remove_proxy(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'no_proxy'
+        })
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.remove_proxy()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_proxy(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'open_proxy'
+        })
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.create_proxy()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_probe_proxy(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'open_proxy'
+        })
+        data = {
+            "enabled": "yes",
+            "url": "http://h-proxy3.ssd.hursley.ibm.com",
+            "port": "3127",
+            "username": "",
+            "password_set": "no",
+            "certificate": "0 fields"
+        }
+        ch = IBMSVCCallhome()
+        data = ch.probe_proxy(data)
+        self.assertEqual(data['port'], 3128)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_proxy(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'open_proxy'
+        })
+        data = {
+            'port': 3128
+        }
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.update_proxy(data)
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_get_existing_cloud_callhome_data(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'disabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'open_proxy'
+        })
+        mock_soi.return_value = {
+            "status": "disabled",
+            "connection": "",
+            "error_sequence_number": "",
+            "last_success": "",
+            "last_failure": ""
+        }
+        ch = IBMSVCCallhome()
+        data = ch.get_existing_cloud_callhome_data()
+        self.assertEqual(data['status'], 'disabled')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_enable_cloud_callhome(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'enabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'open_proxy'
+        })
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.enable_cloud_callhome()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_disable_cloud_callhome(self, mock_svc_authorize, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'disabled',
+            'callhome_type': 'cloud services',
+            'company_name': 'company_name',
+            'address': 'address',
+            'city': 'city',
+            'province': 'PRV',
+            'postalcode': '123456',
+            'country': 'US',
+            'location': 'location',
+            'contact_name': 'contact_name',
+            'contact_email': 'test@domain.com',
+            'phonenumber_primary': '1234567890',
+            'serverIP': '9.20.118.16',
+            'serverPort': 25,
+            'proxy_url': 'http://h-proxy3.ssd.hursley.ibm.com',
+            'proxy_port': 3128,
+            'proxy_type': 'open_proxy'
+        })
+        mock_src.return_value = ''
+        ch = IBMSVCCallhome()
+        data = ch.disable_cloud_callhome()
+        self.assertEqual(data, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_ownershipgroup.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_ownershipgroup.py
@@ -1,0 +1,320 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_svc_manage_ownershipgroup """
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_svc_manage_ownershipgroup import \
+    IBMSVCOwnershipgroup
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVCOwnershipgroup(unittest.TestCase):
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def set_default_args(self):
+        return dict({
+            'name': 'test',
+            'state': 'present'
+        })
+
+    def test_module_fail_when_required_args_missing(self):
+        """ required arguments are reported as errors """
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({})
+            IBMSVCOwnershipgroup()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_fail_when_name_parameter_missing(self):
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({
+                'clustername': 'clustername',
+                'domain': 'domain',
+                'state': 'present',
+                'username': 'username',
+                'password': 'password'
+            })
+            IBMSVCOwnershipgroup()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_fail_when_name_is_blank(self):
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({
+                'clustername': 'clustername',
+                'domain': 'domain',
+                'state': 'present',
+                'username': 'username',
+                'password': 'password',
+                'name': ''
+            })
+            IBMSVCOwnershipgroup()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_fail_when_state_parameter_missing(self):
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({
+                'clustername': 'clustername',
+                'domain': 'domain',
+                'name': 'ansible_owshgroup',
+                'username': 'username',
+                'password': 'password'
+            })
+            IBMSVCOwnershipgroup()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_fail_when_state_parameter_is_blank(self):
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({
+                'clustername': 'clustername',
+                'domain': 'domain',
+                'name': 'ansible_owshgroup',
+                'username': 'username',
+                'password': 'password',
+                'state': ''
+            })
+            IBMSVCOwnershipgroup()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_ownershipgroup.IBMSVCOwnershipgroup.check_existing_owgroups')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_ownershipgroup_with_keepobjects(self,
+                                                    svc_authorize_mock,
+                                                    check_existing_ownership_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansible_owshgroup',
+            'keepobjects': True
+        })
+
+        check_existing_ownership_mock.return_value = False
+
+        ownership = IBMSVCOwnershipgroup()
+        with pytest.raises(AnsibleFailJson) as exc:
+            ownership.apply()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_ownershipgroup.IBMSVCOwnershipgroup.check_existing_owgroups')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_ownershipgroup(self, svc_authorize_mock,
+                                   svc_run_mock,
+                                   check_existing_ownership_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansible_owshgroup'
+        })
+        message = {
+            'id': '0',
+            'message': 'Ownership Group, id [0], successfully created'
+        }
+        svc_run_mock.return_value = message
+        check_existing_ownership_mock.return_value = {}
+
+        ownership = IBMSVCOwnershipgroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ownership.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_ownershipgroup.IBMSVCOwnershipgroup.check_existing_owgroups')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_existing_owgroups(self,
+                                      svc_authorize_mock,
+                                      check_existing_ownership_mock):
+
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansible_owshgroup'
+        })
+        return_val = {
+            'id': '0',
+            'name': 'ansible_owshgroup'
+        }
+        check_existing_ownership_mock.return_value = return_val
+        ownership = IBMSVCOwnershipgroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ownership.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_ownershipgroup.IBMSVCOwnershipgroup.check_existing_owgroups')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_delete_owgrp_without_keepobjs(self,
+                                           svc_authorize_mock,
+                                           check_existing_ownership_mock,
+                                           svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'absent',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansible_owshgroup'
+        })
+        check_existing_ownership_mock.return_value = True
+        ownership = IBMSVCOwnershipgroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ownership.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_ownershipgroup.IBMSVCOwnershipgroup.check_existing_owgroups')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    def test_delete_owgrp_with_keepobjs_scenario_1(self,
+                                                   svc_run_command_mock,
+                                                   check_existing_ownership_mock,
+                                                   svc_authorize_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'absent',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansible_owshgroup',
+            'keepobjects': True
+        })
+        check_existing_ownership_mock.return_value = True
+        ownership = IBMSVCOwnershipgroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ownership.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_ownershipgroup.IBMSVCOwnershipgroup.check_existing_owgroups')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_token_wrap')
+    def test_delete_owgrp_with_keepobjs_scenario_2(self,
+                                                   svc_token_mock,
+                                                   check_existing_ownership_mock,
+                                                   svc_authorize_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'absent',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansible_owshgroup',
+            'keepobjects': True
+        })
+
+        check_existing_ownership_mock.return_value = True
+        svc_token_mock.return_value = {
+            'err': True,
+            'out': 'Ownership group associated with one or more usergroup'
+        }
+        ownership = IBMSVCOwnershipgroup()
+        with pytest.raises(AnsibleFailJson) as exc:
+            ownership.apply()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_ownershipgroup.IBMSVCOwnershipgroup.check_existing_owgroups')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    def test_delete_owgrp_non_existence(self,
+                                        svc_run_command_mock,
+                                        check_existing_owgroup_mock,
+                                        svc_authorize_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'absent',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansible_owshgroup',
+            'keepobjects': True
+        })
+        check_existing_owgroup_mock.return_value = False
+        ownership = IBMSVCOwnershipgroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ownership.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_sra.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_sra.py
@@ -1,0 +1,401 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_svc_manage_sra """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_svc_manage_sra import IBMSVCSupportRemoteAssistance
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVCSupportRemoteAssistance(unittest.TestCase):
+    """
+    Group of related Unit Tests
+    """
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def test_module_required_if_functionality(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote'
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_required_together_functionality(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': []
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_with_empty_list(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': [],
+            'sra_ip': [],
+            'sra_port': []
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_with_blank_value_in_list(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': [''],
+            'sra_ip': [''],
+            'sra_port': ['']
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_without_state_parameter(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'support': 'onsite'
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_onsite_with_unnecessary_args(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'support': 'onsite',
+            'name': ['test_proxy']
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_with_unequal_proxy_arguments(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': ['dummy_proxy'],
+            'sra_ip': ['9.9.9.9', '9.9.9.9'],
+            'sra_port': []
+        })
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_enable_sra_onsite(self, svc_authorize_mock,
+                               svc_run_command_mock,
+                               sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'onsite',
+        })
+
+        sra_enabled_mock.return_value = False
+
+        sra_inst = IBMSVCSupportRemoteAssistance()
+        with pytest.raises(AnsibleExitJson) as exc:
+            sra_inst.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.add_proxy_details')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_enable_sra_remote_with_proxy(self, svc_authorize_mock,
+                                          svc_run_command_mock,
+                                          add_proxy_mock,
+                                          sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': ['customer_proxy'],
+            'sra_ip': ['10.10.10.10'],
+            'sra_port': [8888]
+        })
+
+        sra_enabled_mock.return_value = False
+
+        sra_inst = IBMSVCSupportRemoteAssistance()
+        with pytest.raises(AnsibleExitJson) as exc:
+            sra_inst.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.remove_proxy_details')
+    def test_disable_sra_remote_negative(self, remove_proxy_mock,
+                                         svc_authorize_mock,
+                                         svc_run_command_mock,
+                                         sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'disabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': ['customer_proxy'],
+            'sra_ip': ['10.10.10.10'],
+            'sra_port': [8888]
+        })
+
+        sra_enabled_mock.return_value = True
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVCSupportRemoteAssistance()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.remove_proxy_details')
+    def test_disable_sra_remote(self, remove_proxy_mock,
+                                svc_authorize_mock,
+                                svc_run_command_mock,
+                                sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'disabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': ['customer_proxy']
+        })
+
+        sra_enabled_mock.return_value = True
+
+        sra_inst = IBMSVCSupportRemoteAssistance()
+        with pytest.raises(AnsibleExitJson) as exc:
+            sra_inst.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_enable_sra_twice(self, svc_authorize_mock,
+                              svc_run_command_mock,
+                              svc_obj_info_mock,
+                              sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'onsite',
+        })
+
+        svc_obj_info_mock.return_value = {'remote_support_enabled': 'yes'}
+        sra_enabled_mock.return_value = True
+
+        sra_inst = IBMSVCSupportRemoteAssistance()
+        with pytest.raises(AnsibleExitJson) as exc:
+            sra_inst.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_remote_support_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.add_proxy_details')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_sra(self, svc_authorize_mock,
+                        add_proxy_mock,
+                        remote_enabled_mock,
+                        sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'enabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'remote',
+            'name': ['customer_proxy'],
+            'sra_ip': ['10.10.10.10'],
+            'sra_port': [8888]
+        })
+
+        sra_enabled_mock.return_value = True
+        remote_enabled_mock.return_value = False
+        add_proxy_mock.return_value = []
+
+        sra_inst = IBMSVCSupportRemoteAssistance()
+        with pytest.raises(AnsibleExitJson) as exc:
+            sra_inst.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_disable_sra(self, svc_authorize_mock,
+                         svc_run_command_mock,
+                         sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'disabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'onsite',
+        })
+
+        sra_enabled_mock.return_value = True
+
+        sra_inst = IBMSVCSupportRemoteAssistance()
+        with pytest.raises(AnsibleExitJson) as exc:
+            sra_inst.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_svc_manage_sra.IBMSVCSupportRemoteAssistance.is_sra_enabled')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_disable_sra_twice(self, svc_authorize_mock,
+                               svc_run_command_mock,
+                               sra_enabled_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'disabled',
+            'username': 'username',
+            'password': 'password',
+            'support': 'onsite',
+        })
+
+        sra_enabled_mock.return_value = False
+
+        sra_inst = IBMSVCSupportRemoteAssistance()
+        with pytest.raises(AnsibleExitJson) as exc:
+            sra_inst.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_user.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_user.py
@@ -1,0 +1,521 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_svc_usergroup """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_svc_manage_user import IBMSVCUser
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVCUser(unittest.TestCase):
+    """ a group of related Unit Tests"""
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def set_default_args(self):
+        return dict({
+            'name': 'test',
+            'state': 'present'
+        })
+
+    def test_module_fail_when_required_args_missing(self):
+        """ required arguments are reported as errors """
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({})
+            IBMSVCUser()
+        print('Info: %s' % exc.value.args[0]['msg'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_get_existing_user(self, mock_svc_authorize, svc_obj_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'auth_type': 'usergrp',
+            'usergroup': 'Service',
+        })
+        svc_obj_info_mock.return_value = {
+            "id": "3",
+            "name": "userx",
+            "password": "yes",
+            "ssh_key": "no",
+            "remote": "no",
+            "usergrp_id": "3",
+            "usergrp_name": "Service",
+            "owner_id": "",
+            "owner_name": "",
+            "locked": "no",
+            "locked_until": "",
+            "password_expiry_time": "",
+            "password_change_required": "no"
+        }
+        ug = IBMSVCUser()
+        data = ug.get_existing_user()
+        self.assertEqual(data["name"], "userx")
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_basic_checks(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'auth_type': 'usergrp',
+            'usergroup': 'Service',
+        })
+        ug = IBMSVCUser()
+        data = ug.basic_checks()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_get_existing_user(self, mock_svc_authorize, svc_obj_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'auth_type': 'usergrp',
+            'usergroup': 'Service',
+        })
+        svc_obj_info_mock.return_value = {
+            "id": "3",
+            "name": "userx",
+            "password": "yes",
+            "ssh_key": "no",
+            "remote": "no",
+            "usergrp_id": "3",
+            "usergrp_name": "Service",
+            "owner_id": "",
+            "owner_name": "",
+            "locked": "no",
+            "locked_until": "",
+            "password_expiry_time": "",
+            "password_change_required": "no"
+        }
+        ug = IBMSVCUser()
+        data = ug.get_existing_user()
+        self.assertEqual(data["name"], "userx")
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_user(self, mock_svc_authorize, svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'auth_type': 'usergrp',
+            'usergroup': 'Service',
+        })
+        svc_run_command_mock.return_value = {
+            'id': '3',
+            'message': 'User, id [3], successfully created'
+        }
+        ug = IBMSVCUser()
+        data = ug.create_user()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_probe_user(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'auth_type': 'usergrp',
+            'usergroup': 'Monitor',
+        })
+        data = {
+            "id": "3",
+            "name": "userx",
+            "password": "yes",
+            "ssh_key": "no",
+            "remote": "no",
+            "usergrp_id": "3",
+            "usergrp_name": "Service",
+            "owner_id": "",
+            "owner_name": "",
+            "locked": "no",
+            "locked_until": "",
+            "password_expiry_time": "",
+            "password_change_required": "no"
+        }
+        ug = IBMSVCUser()
+        result = ug.probe_user(data)
+        self.assertEqual(result['usergrp'], 'Monitor')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_user(self, mock_svc_authorize, svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'auth_type': 'usergrp',
+            'usergroup': 'Monitor',
+        })
+        data = {
+            'usergrp': 'Monitor',
+            'password': 'Test@123'
+        }
+        svc_run_command_mock.return_value = None
+        ug = IBMSVCUser()
+        result = ug.update_user(data)
+        self.assertEqual(result, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_remove_user(self, mock_svc_authorize, svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'absent',
+            'name': 'userx',
+        })
+        svc_run_command_mock.return_value = None
+        ug = IBMSVCUser()
+        result = ug.remove_user()
+        self.assertEqual(result, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_creating_new_user(self, mock_svc_authorize, mock_soi, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'absent',
+            'name': 'userx',
+            'user_password': 'userx@123',
+            'usergroup': 'Monitor'
+        })
+        mock_soi.return_value = {}
+        mock_src.return_value = {
+            'id': '3',
+            'message': 'User, id [3], successfully created'
+        }
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_creating_existing_user(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'usergroup': 'Service'
+        })
+        mock_soi.return_value = {
+            "id": "3",
+            "name": "userx",
+            "password": "yes",
+            "ssh_key": "no",
+            "remote": "no",
+            "usergrp_id": "3",
+            "usergrp_name": "Service",
+            "owner_id": "",
+            "owner_name": "",
+            "locked": "no",
+            "locked_until": "",
+            "password_expiry_time": "",
+            "password_change_required": "no"
+        }
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_updating_user(self, mock_svc_authorize, mock_soi, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'usergroup': 'Monitor',
+            'lock': True,
+            'forcepasswordchange': True
+        })
+        mock_soi.return_value = {
+            "id": "3",
+            "name": "userx",
+            "password": "yes",
+            "ssh_key": "no",
+            "remote": "no",
+            "usergrp_id": "3",
+            "usergrp_name": "Service",
+            "owner_id": "",
+            "owner_name": "",
+            "locked": "no",
+            "locked_until": "",
+            "password_expiry_time": "",
+            "password_change_required": "no"
+        }
+        mock_src.return_value = None
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_removing_existing_user(self, mock_svc_authorize, mock_soi, mock_src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'absent',
+            'name': 'userx',
+        })
+        mock_soi.return_value = {
+            "id": "3",
+            "name": "userx",
+            "password": "yes",
+            "ssh_key": "no",
+            "remote": "no",
+            "usergrp_id": "3",
+            "usergrp_name": "Service",
+            "owner_id": "",
+            "owner_name": "",
+            "locked": "no",
+            "locked_until": "",
+            "password_expiry_time": "",
+            "password_change_required": "no"
+        }
+        mock_src.return_value = None
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_removing_non_existing_user(self, mock_svc_authorize, mock_soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'absent',
+            'name': 'userx',
+        })
+        mock_soi.return_value = {}
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_missing_mandatory_parameters(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_missing_parameter_during_creation(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'userx',
+            'state': 'present',
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_mutually_exclusive_nopassword(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'nopassword': True,
+            'auth_type': 'usergrp',
+            'usergroup': 'Service',
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_mutually_exclusive_nokey(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'keyfile': 'keyfile-path',
+            'nokey': True,
+            'auth_type': 'usergrp',
+            'usergroup': 'Service',
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_mutually_exclusive_nokey(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present',
+            'name': 'userx',
+            'user_password': 'Test@123',
+            'keyfile': 'keyfile-path',
+            'auth_type': 'usergrp',
+            'usergroup': 'Service',
+            'lock': True,
+            'unlock': True
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUser()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_usergroup.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_usergroup.py
@@ -1,0 +1,448 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_svc_usergroup """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_svc_manage_usergroup import IBMSVCUsergroup
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVCUsergroup(unittest.TestCase):
+    """ a group of related Unit Tests"""
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def set_default_args(self):
+        return dict({
+            'name': 'test',
+            'state': 'present'
+        })
+
+    def test_module_fail_when_required_args_missing(self):
+        """ required arguments are reported as errors """
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({})
+            IBMSVCUsergroup()
+        print('Info: %s' % exc.value.args[0]['msg'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_basic_checks(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Monitor',
+            'ownershipgroup': 'ownershipgroupx'
+        })
+        ug = IBMSVCUsergroup()
+        data = ug.basic_checks()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_get_existing_usergroup(self, mock_svc_authorize, svc_obj_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Monitor',
+            'ownershipgroup': 'ownershipgroupx'
+        })
+        svc_obj_info_mock.return_value = {
+            "id": "8",
+            "name": "test_usergrp",
+            "role": "Monitor",
+            "remote": "no",
+            "owner_id": "1",
+            "owner_name": "ownershipgroupx"
+        }
+        ug = IBMSVCUsergroup()
+        data = ug.get_existing_usergroup()
+        self.assertEqual(data["name"], "test_usergrp")
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_user_group(self, mock_svc_authorize, svc_run_command):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Monitor',
+            'ownershipgroup': 'ownershipgroupx'
+        })
+        svc_run_command.return_value = {
+            "message": "User Group, id [6], successfully created",
+            "id": 6
+        }
+        ug = IBMSVCUsergroup()
+        data = ug.create_user_group()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_probe_user_group(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Monitor',
+            'ownershipgroup': 'ownershipgroupx'
+        })
+        data = {
+            "id": "8",
+            "name": "test_usergrp",
+            "role": "Service",
+            "remote": "no",
+            "owner_id": "1",
+            "owner_name": "ownershipgroupy"
+        }
+        ug = IBMSVCUsergroup()
+        data = ug.probe_user_group(data)
+        self.assertTrue('role' in data)
+        self.assertTrue('ownershipgroup' in data)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_user_group(self, mock_svc_authorize, svc_run_command):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Monitor',
+            'ownershipgroup': 'ownershipgroupx'
+        })
+        data = {
+            "role": "Service",
+            "ownershipgroup": "ownershipgroupy"
+        }
+        ug = IBMSVCUsergroup()
+        data = ug.update_user_group(data)
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_remove_user_group(self, mock_svc_authorize, svc_run_command):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'absent',
+        })
+        svc_run_command.return_value = None
+        ug = IBMSVCUsergroup()
+        data = ug.remove_user_group()
+        self.assertEqual(data, None)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_new_ownershipgroup(self, mock_svc_authorize, soi, src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Monitor',
+            'ownershipgroup': 'ownershipgroupx'
+        })
+        soi.return_value = {}
+        src.return_value = {
+            "message": "User Group, id [6], successfully created",
+            "id": 6
+        }
+        ug = IBMSVCUsergroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_existing_ownershipgroup(self, mock_svc_authorize, soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Monitor',
+            'ownershipgroup': 'ownershipgroupx'
+        })
+        soi.return_value = {
+            "id": "8",
+            "name": "test_usergrp",
+            "role": "Monitor",
+            "remote": "no",
+            "owner_id": "1",
+            "owner_name": "ownershipgroupx"
+        }
+        ug = IBMSVCUsergroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug.apply()
+            self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_existing_ownershipgroup(self, mock_svc_authorize, soi, src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Service',
+            'ownershipgroup': 'ownershipgroupy'
+        })
+        soi.return_value = {
+            "id": "8",
+            "name": "test_usergrp",
+            "role": "Monitor",
+            "remote": "no",
+            "owner_id": "1",
+            "owner_name": "ownershipgroupx"
+        }
+        src.return_value = None
+        ug = IBMSVCUsergroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_noownershipgroup(self, mock_svc_authorize, soi, src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'present',
+            'role': 'Service',
+            'noownershipgroup': True
+        })
+        soi.return_value = {
+            "id": "8",
+            "name": "test_usergrp",
+            "role": "Monitor",
+            "remote": "no",
+            "owner_id": "1",
+            "owner_name": "ownershipgroupx"
+        }
+        src.return_value = None
+        ug = IBMSVCUsergroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_remove_existing_ownershipgroup(self, mock_svc_authorize, soi, src):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'absent',
+        })
+        soi.return_value = {
+            "id": "8",
+            "name": "test_usergrp",
+            "role": "Monitor",
+            "remote": "no",
+            "owner_id": "1",
+            "owner_name": "ownershipgroupx"
+        }
+        src.return_value = None
+        ug = IBMSVCUsergroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_remove_non_existing_ownershipgroup(self, mock_svc_authorize, soi):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'state': 'absent',
+        })
+        soi.return_value = {}
+        ug = IBMSVCUsergroup()
+        with pytest.raises(AnsibleExitJson) as exc:
+            ug.apply()
+            self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_failure_missing_name_parameter(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'state': 'absent',
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUsergroup()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_failure_missing_state_parameter(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_usergrp'
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUsergroup()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_failure_missing_role_parameter_during_creation(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_usergrp',
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUsergroup()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_mutually_exclusive_noownershipgroup(self, mock_svc_authorize):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_usergrp',
+            'state': 'present',
+            'ownershipgroup': 'ownershipgroup-name',
+            'noownershipgroup': True
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            ug = IBMSVCUsergroup()
+            ug.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
1. Added support for creating, updating and deleting a user
2. Added support for creating, updating and deleting a user group
3. Added support for creating and deleting an ownership group
4. Added support for configuring the Call Home feature
5. Added support for 'remote assistance' configuration
6. Added support for automating initial configuration like setting system name, date, time, NTP, licensed funcitons and DNS.

##### COMPONENT NAME
ibm_svc_manage_user
ibm_svc_manage_usergroup
ibm_svc_manage_ownershipgroup
ibm_svc_manage_callhome
ibm_svc_manage_sra
ibm_svc_initial_setup
