### PR TITLE
IBM Spectrum Virtualize Collection v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Code of conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html )
 
-This collection provides a series of Ansible modules and plugins for interacting with the IBM Spectrum Virtualize family storage products. These products include the IBM SAN Volume Controller, IBM FlashSystem family members built with IBM Spectrum Virtualize (FlashSystem 5xxx, 7xxx, 9xxx), IBM Storwize family, and IBM Spectrum Virtualize for Public Cloud. For more information regarding these products, see [IBM Documentation](https://www.ibm.com/docs/en ).
+This collection provides a series of Ansible modules and plugins for interacting with the IBM Spectrum Virtualize family storage products. These products include the IBM SAN Volume Controller, IBM FlashSystem family members built with IBM Spectrum Virtualize (FlashSystem 5xxx, 7xxx, 9xxx), IBM Storwize family, and IBM Spectrum Virtualize for Public Cloud. For more information regarding these products, see [IBM Documentation](https://www.ibm.com/docs/).
 
 ## Requirements
 
@@ -68,39 +68,44 @@ Alternatively, you can add a full namepsace and collection name in the `collecti
 
 ### Modules
 
-- ibm_svc_auth - Generates an authentication token for a user on IBM Spectrum Virtualize family storage system
+- ibm_svc_auth - Generates an authentication token for a user on Spectrum Virtualize storage systems
 - ibm_svc_complete_initial_setup - Completes the initial setup configuration for LMC systems
-- ibm_svc_host - Manages hosts on IBM Spectrum Virtualize system
-- ibm_svc_hostcluster - Manages host cluster on IBM Spectrum Virtualize system
-- ibm_svc_info - Collects information on IBM Spectrum Virtualize system
-- ibm_svc_initial_setup - Manages initial setup configuration on IBM Spectrum Virtualize system
-- ibm_svc_manage_callhome - Manages configuration of Call Home feature on IBM Spectrum Virtualize system
-- ibm_svc_manage_consistgrp_flashcopy - Manages FlashCopy consistency groups on IBM Spectrum Virtualize system
-- ibm_svc_manage_cv - Manages the change volume in remote copy replication on IBM Spectrum Virtualize system
-- ibm_svc_manage_flashcopy - Manages FlashCopy mappings on IBM Spectrum Virtualize system
-- ibm_svc_manage_ip - Manages IP provisioning on IBM Spectrum Virtualize system
-- ibm_svc_manage_mirrored_volume - Manages mirrored volumes on IBM Spectrum Virtualize system
-- ibm_svc_manage_migration - Manages volume migration between clusters on IBM Spectrum Virtualize system
-- ibm_svc_manage_ownershipgroup - Manages ownership groups on IBM Spectrum Virtualize system
-- ibm_svc_manage_portset - Manages IP portset on IBM Spectrum Virtualize system
-- ibm_svc_manage_replication - Manages remote copy replication on IBM Spectrum Virtualize system
-- ibm_svc_manage_replicationgroup - Manages remote copy consistency groups on IBM Spectrum Virtualize system
-- ibm_svc_manage_safeguarded_policy - Manages safeguarded policy configuration on IBM Spectrum Virtualize system
-- ibm_svc_manage_sra - Manages the remote support assistance configuration on IBM Spectrum Virtualize system
-- ibm_svc_manage_user - Manages user on IBM Spectrum Virtualize system
-- ibm_svc_manage_usergroup - Manages user groups on IBM Spectrum Virtualize system
-- ibm_svc_manage_volume - Manages standard volumes on IBM Spectrum Virtualize system
-- ibm_svc_manage_volumegroup - Manages volume groups on IBM Spectrum Virtualize system
-- ibm_svc_mdisk - Manages MDisks for IBM Spectrum Virtualize system
-- ibm_svc_mdiskgrp - Manages pools for IBM Spectrum Virtualize system
-- ibm_svc_start_stop_flashcopy - Starts or stops FlashCopy mapping and consistency groups on IBM Spectrum Virtualize system
-- ibm_svc_start_stop_replication - Starts or stops remote-copy independent relationships or consistency groups on IBM Spectrum Virtualize system
-- ibm_svc_vol_map - Manages volume mapping for IBM Spectrum Virtualize system
-- ibm_svcinfo_command - Runs svcinfo CLI command on IBM Spectrum Virtualize system over SSH session
-- ibm_svctask_command - Runs svctask CLI command(s) on IBM Spectrum Virtualize system over SSH session
-- ibm_sv_manage_ip_partnership - Manages IP partnership configuration on IBM Spectrum Virtualize systems
-- ibm_sv_manage_snapshot - Manages snapshots (mutual consistent images of a volume) on IBM Spectrum Virtualize systems
-- ibm_sv_manage_snapshotpolicy - Manages snapshot policy configuration on IBM Spectrum Virtualize systems
+- ibm_svc_host - Manages hosts on Spectrum Virtualize storage systems
+- ibm_svc_hostcluster - Manages host cluster on Spectrum Virtualize storage systems
+- ibm_svc_info - Collects information on Spectrum Virtualize storage systems
+- ibm_svc_initial_setup - Manages initial setup configuration on Spectrum Virtualize storage systems
+- ibm_svc_manage_callhome - Manages configuration of Call Home feature on Spectrum Virtualize storage systems
+- ibm_svc_manage_consistgrp_flashcopy - Manages FlashCopy consistency groups on Spectrum Virtualize storage systems
+- ibm_svc_manage_cv - Manages the change volume in remote copy replication on Spectrum Virtualize storage systems
+- ibm_svc_manage_flashcopy - Manages FlashCopy mappings on Spectrum Virtualize storage systems
+- ibm_svc_manage_ip - Manages IP provisioning on Spectrum Virtualize storage systems
+- ibm_svc_manage_migration - Manages volume migration between clusters on Spectrum Virtualize storage systems
+- ibm_svc_manage_mirrored_volume - Manages mirrored volumes on Spectrum Virtualize storage systems
+- ibm_svc_manage_ownershipgroup - Manages ownership groups on Spectrum Virtualize storage systems
+- ibm_svc_manage_portset - Manages IP portset on Spectrum Virtualize storage systems
+- ibm_svc_manage_replication - Manages remote copy replication on Spectrum Virtualize storage systems
+- ibm_svc_manage_replicationgroup - Manages remote copy consistency groups on Spectrum Virtualize storage systems
+- ibm_svc_manage_safeguarded_policy - Manages safeguarded policy configuration on Spectrum Virtualize storage systems
+- ibm_svc_manage_sra - Manages the remote support assistance configuration on Spectrum Virtualize storage systems
+- ibm_svc_manage_user - Manages user on Spectrum Virtualize storage systems
+- ibm_svc_manage_usergroup - Manages user groups on Spectrum Virtualize storage systems
+- ibm_svc_manage_volume - Manages standard volumes on Spectrum Virtualize storage systems
+- ibm_svc_manage_volumegroup - Manages volume groups on Spectrum Virtualize storage systems
+- ibm_svc_mdisk - Manages MDisks for Spectrum Virtualize storage systems
+- ibm_svc_mdiskgrp - Manages pools for Spectrum Virtualize storage systems
+- ibm_svc_start_stop_flashcopy - Starts or stops FlashCopy mapping and consistency groups on Spectrum Virtualize storage systems
+- ibm_svc_start_stop_replication - Starts or stops remote-copy independent relationships or consistency groups on Spectrum Virtualize storage systems
+- ibm_svc_vol_map - Manages volume mapping for Spectrum Virtualize storage systems
+- ibm_svcinfo_command - Runs svcinfo CLI command on Spectrum Virtualize storage systems over SSH session
+- ibm_svctask_command - Runs svctask CLI command(s) on Spectrum Virtualize storage systems over SSH session
+- ibm_sv_manage_ip_partnership - Manages IP partnership configuration on Spectrum Virtualize storage systems
+- ibm_sv_manage_provisioning_policy - Manages provisioning policy configuration on Spectrum Virtualize storage systems
+- ibm_sv_manage_replication_policy - Manages policy-based replication configuration on Spectrum Virtualize storage systems
+- ibm_sv_manage_snapshot - Manages snapshots (mutual consistent images of a volume) on Spectrum Virtualize storage systems
+- ibm_sv_manage_snapshotpolicy - Manages snapshot policy configuration on Spectrum Virtualize storage systems
+- ibm_sv_manage_SSL_certificate - Exports an existing system certificate on to Spectrum Virtualize storage systems
+- ibm_sv_manage_truststore_for_replication - Manages certificate trust stores for replication on Spectrum Virtualize family storage systems
+- ibm_sv_switch_replication_direction - Switches the replication direction on Spectrum Virtualize storage systems
 
 ### Other Feature Information
 - SV Ansible Collection v1.8.0 provides the new 'ibm_svc_complete_initial_setup' module, to complete the automation of Day 0 configuration on Licensed Machine Code (LMC) systems.
@@ -121,7 +126,7 @@ Alternatively, you can add a full namepsace and collection name in the `collecti
 The modules in the IBM Spectrum Virtualize Ansible collection leverage REST APIs to connect to the IBM Spectrum Virtualize storage system. This has following limitations:
 1. Using the REST APIs to list more than 2000 objects may create a loss of service from the API side, as it automatically restarts due to memory constraints.
 2. It is not possible to access REST APIs using an IPv6 address on a cluster.
-3. The Ansible collection can run on all IBM Spectrum Virtualize storage versions above 8.1.3, except versions 8.3.1.3 and 8.3.1.4.
+3. The Ansible collection can run on all IBM Spectrum Virtualize storage system versions above 8.1.3, except versions 8.3.1.3 and 8.3.1.4.
 4. At time of release of the SV Ansible v1.8.0 collection, no module is available for non LMC systems to automate license agreements acceptance, including EULA.
    User will be presented with a GUI setup wizard upon user-interface login, whether the Ansible modules have been used for initial configuration or not.
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -82,3 +82,24 @@ releases:
     - description: Manages snapshot policy configuration on Spectrum Virtualize storage systems
       name: ibm_sv_manage_snapshotpolicy
       namespace: ''
+  1.10.0:
+    release_date: '2022-9-30'
+    changes:
+      release_summary: Added new modules for managing provisioning policy and managing policy based replication.
+        Also added support to use an existing SSL certificate to create mTLS partnership between partner systems.
+    modules:
+    - description: Manages provisioning policy on Spectrum Virtualize systems
+      name: ibm_sv_manage_provisioning_policy
+      namespace: ''
+    - description: Manages policy based replication on Spectrum Virtualize systems
+      name: ibm_sv_manage_replication_policy
+      namespace: ''
+    - description: Allows user to switch replication direction in case of DR on Spectrum Virtualize storage systems
+      name: ibm_sv_switch_replication_direction
+      namespace: ''
+    - description: Allows user to export an existing system certificate on Spectrum Virtualize storage systems
+      name: ibm_sv_manage_SSL_certificate
+      namespace: ''
+    - description: Manages the certificates trust store on Spectrum Virtualize storage systems
+      name: ibm_sv_manage_truststore_for_replication
+      namespace: ''

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ibm
 name: spectrum_virtualize
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.9.0
+version: 1.10.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -17,11 +17,9 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-- Peng Wang <wangpww@cn.ibm.com>
 - Shilpi Jain <shilpi.jain1@ibm.com>
-- Rohit Kumar <rohit.kumar6@ibm.com>
-- Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
 - Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+- Rohit Kumar <rohit.kumar6@ibm.com>
 
 
 ### OPTIONAL but strongly recommended

--- a/plugins/module_utils/ibm_svc_utils.py
+++ b/plugins/module_utils/ibm_svc_utils.py
@@ -51,6 +51,22 @@ def svc_ssh_argument_spec():
     )
 
 
+def strtobool(val):
+    '''
+    Converts a string representation to boolean.
+
+    This is a built-in function available in python till the version 3.9 under disutils.util
+    but this has been deprecated in 3.10 and may not be available in future python releases
+    so adding the source code here.
+    '''
+    if val in {'y', 'yes', 't', 'true', 'on', '1'}:
+        return 1
+    elif val in {'n', 'no', 'f', 'false', 'off', '0'}:
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
 def get_logger(module_name, log_file_name, log_level=logging.INFO):
     FORMAT = '%(asctime)s.%(msecs)03d %(levelname)5s %(thread)d %(filename)s:%(funcName)s():%(lineno)s %(message)s'
     DATEFORMAT = '%Y-%m-%dT%H:%M:%S'

--- a/plugins/modules/ibm_sv_manage_SSL_certificate.py
+++ b/plugins/modules/ibm_sv_manage_SSL_certificate.py
@@ -1,0 +1,158 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ibm_sv_manage_SSL_certificate
+short_description: This module exports existing system-signed certificate on to IBM Spectrum Virtualize family storage systems
+version_added: '1.10.0'
+description:
+  - Only existing system-signed certificates can be exported. External authority certificate generation is not supported.
+options:
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when the hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    certificate_type:
+        description:
+            - Specify the certificate type to be exported.
+        choices: [ 'system' ]
+        default: 'system'
+        type: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+author:
+    - Sanjaikumaar M(@sanjaikumaar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Export SSL certificate internally
+  ibm_sv_manage_SSL_certificate:
+    clustername: "x.x.x.x"
+    username: "username"
+    password: "password"
+    certificate_type: "system"
+'''
+
+RETURN = '''#'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import (
+    IBMSVCRestApi, svc_argument_spec,
+    get_logger
+)
+from ansible.module_utils._text import to_native
+
+
+class IBMSVSSLCertificate:
+
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                certificate_type=dict(
+                    type='str',
+                    choices=['system'],
+                    default='system'
+                )
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+        # Default parameters
+        self.certificate_type = self.module.params['certificate_type']
+
+        # logging setup
+        self.log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, self.log_path)
+        self.log = log.info
+
+        # Dynamic variables
+        self.changed = False
+        self.msg = ''
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=self.log_path,
+            token=self.module.params['token']
+        )
+
+    def export_cert(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        self.restapi.svc_run_command('chsystemcert', cmdopts=None, cmdargs=['-export'])
+        self.log('Certificate exported')
+        self.changed = True
+
+    def apply(self):
+        if self.certificate_type == 'system':
+            self.export_cert()
+            self.msg = 'Certificate exported.'
+
+        if self.module.check_mode:
+            self.msg = 'skipping changes due to check mode.'
+
+        self.module.exit_json(
+            changed=self.changed,
+            msg=self.msg
+        )
+
+
+def main():
+    v = IBMSVSSLCertificate()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log('Exception in apply(): \n%s', format_exc())
+        v.module.fail_json(msg='Module failed. Error [%s].' % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_sv_manage_provisioning_policy.py
+++ b/plugins/modules/ibm_sv_manage_provisioning_policy.py
@@ -1,0 +1,343 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ibm_sv_manage_provisioning_policy
+short_description: This module configures and manages provisioning policies on IBM Spectrum Virtualize family storage systems
+version_added: '1.10.0'
+description:
+  - Ansible interface to manage mkprovisioningpolicy, chprovisioningpolicy, and rmprovisioningpolicy commands.
+options:
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    state:
+        description:
+            - Creates, updates (C(present)), or deletes (C(absent)) a provisioning policy.
+        choices: [ present, absent ]
+        required: true
+        type: str
+    name:
+        description:
+            - Specifies the name of the provisioning policy.
+            - Specifies the new name during rename.
+        type: str
+        required: true
+    capacitysaving:
+        description:
+            - Specifies the policy capacity savings.
+            - Applies, when I(state=present), to create a provisioning policy.
+        choices: [ drivebased, thin, compressed ]
+        type: str
+    deduplicated:
+        description:
+            - Specifies when volumes should be deduplicated.
+            - Applicable when I(capacitysaving=thin) or I(capacitysaving=compressed).
+        default: false
+        type: bool
+    old_name:
+        description:
+            - Specifies the old name of the provisioning policy during renaming.
+            - Valid when I(state=present) to rename an existing policy.
+        type: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+author:
+    - Sanjaikumaar M (@sanjaikumaar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Create provisioning policy
+  ibm.spectrum_virtualize.ibm_sv_manage_provisioning_policy:
+    clustername: "{{cluster}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    name: provisioning_policy0
+    capacitysaving: "compressed"
+    deduplicated: true
+    state: present
+- name: Rename provisioning policy
+  ibm.spectrum_virtualize.ibm_sv_manage_provisioning_policy:
+    clustername: "{{cluster}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    name: pp0
+    old_name: provisioning_policy0
+    state: present
+- name: Delete replication policy
+  ibm.spectrum_virtualize.ibm_sv_manage_provisioning_policy:
+    clustername: "{{cluster}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    name: pp0
+    state: absent
+'''
+
+RETURN = '''#'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import (
+    IBMSVCRestApi, svc_argument_spec,
+    get_logger, strtobool
+)
+from ansible.module_utils._text import to_native
+
+
+class IBMSVProvisioningPolicy:
+
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                name=dict(
+                    type='str',
+                    required=True
+                ),
+                state=dict(
+                    type='str',
+                    choices=['present', 'absent'],
+                    required=True
+                ),
+                capacitysaving=dict(
+                    type='str',
+                    choices=['drivebased', 'thin', 'compressed']
+                ),
+                deduplicated=dict(
+                    type='bool',
+                    default=False
+                ),
+                old_name=dict(
+                    type='str',
+                ),
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # Required parameters
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional parameters
+        self.capacitysaving = self.module.params.get('capacitysaving')
+        self.deduplicated = self.module.params.get('deduplicated', False)
+        self.old_name = self.module.params.get('old_name', '')
+
+        self.basic_checks()
+
+        # logging setup
+        self.log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, self.log_path)
+        self.log = log.info
+
+        # Dynamic variables
+        self.changed = False
+        self.msg = ''
+        self.pp_data = {}
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=self.log_path,
+            token=self.module.params['token']
+        )
+
+    def basic_checks(self):
+        if self.state == 'present':
+            if not self.name:
+                self.module.fail_json(
+                    msg='Mandatory parameter missing: name'
+                )
+        else:
+            unsupported = ('capacitysaving', 'deduplicated', 'old_name')
+            unsupported_exists = ','.join(field for field in unsupported if getattr(self, field))
+            if unsupported_exists:
+                self.module.fail_json(
+                    msg='state=absent but following paramters passed: {0}'.format(unsupported_exists)
+                )
+
+    def create_validation(self):
+        if self.old_name:
+            self.rename_validation([])
+
+        if not self.capacitysaving:
+            self.module.fail_json(
+                msg='Mandatory parameter missing: capacitysaving'
+            )
+
+    def rename_validation(self, updates):
+        if self.old_name and self.name:
+            if self.name == self.old_name:
+                self.module.fail_json(msg='New name and old name should be different.')
+
+            new = self.is_pp_exists()
+            existing = self.is_pp_exists(name=self.old_name)
+
+            if existing:
+                if new:
+                    self.module.fail_json(
+                        msg='Provisioning policy ({0}) already exists for the given new name'.format(self.name)
+                    )
+                else:
+                    updates.append('name')
+            else:
+                if not new:
+                    self.module.fail_json(
+                        msg='Provisioning policy ({0}) does not exists for the given old name.'.format(self.old_name)
+                    )
+                else:
+                    self.module.exit_json(
+                        msg='Provisioning policy ({0}) already renamed. No modifications done.'.format(self.name)
+                    )
+
+    def is_pp_exists(self, name=None):
+        result = {}
+        name = name if name else self.name
+        cmd = 'lsprovisioningpolicy'
+        data = self.restapi.svc_obj_info(cmd=cmd, cmdopts=None, cmdargs=[name])
+
+        if isinstance(data, list):
+            for d in data:
+                result.update(d)
+        else:
+            result = data
+
+        self.pp_data = result
+
+        return result
+
+    def create_provisioning_policy(self):
+        self.create_validation()
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'mkprovisioningpolicy'
+        cmdopts = {
+            'name': self.name,
+            'capacitysaving': self.capacitysaving,
+            'deduplicated': self.deduplicated
+        }
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        self.log('Provisioning policy (%s) created', self.name)
+        self.changed = True
+
+    def provisioning_policy_probe(self):
+        updates = []
+        self.rename_validation(updates)
+        if self.capacitysaving:
+            capsav = 'none' if self.capacitysaving == 'drivebased' else self.capacitysaving
+            if capsav and capsav != self.pp_data.get('capacity_saving', ''):
+                self.module.fail_json(msg='Following paramter not applicable for update operation: capacitysaving')
+        if self.deduplicated and not strtobool(self.pp_data.get('deduplicated', 0)):
+            self.module.fail_json(msg='Following paramter not applicable for update operation: deduplicated')
+        return updates
+
+    def update_provisioning_policy(self, updates):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'chprovisioningpolicy'
+        cmdopts = {
+            'name': self.name
+        }
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.old_name])
+        self.log('Provisioning policy (%s) renamed', self.name)
+        self.changed = True
+
+    def delete_provisioning_policy(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'rmprovisioningpolicy'
+        self.restapi.svc_run_command(cmd, cmdopts=None, cmdargs=[self.name])
+        self.changed = True
+
+    def apply(self):
+        if self.is_pp_exists(name=self.old_name):
+            if self.state == 'present':
+                modifications = self.provisioning_policy_probe()
+                if any(modifications):
+                    self.update_provisioning_policy(modifications)
+                    self.msg = 'Provisioning policy ({0}) updated'.format(self.name)
+                else:
+                    self.msg = 'Provisioning policy ({0}) already exists. No modifications done.'.format(self.name)
+            else:
+                self.delete_provisioning_policy()
+                self.msg = 'Provisioning policy ({0}) deleted'.format(self.name)
+        else:
+            if self.state == 'absent':
+                self.msg = 'Provisioning policy ({0}) does not exist.'.format(self.name)
+            else:
+                self.create_provisioning_policy()
+                self.msg = 'Provisioning policy ({0}) created.'.format(self.name)
+
+        if self.module.check_mode:
+            self.msg = 'skipping changes due to check mode.'
+
+        self.module.exit_json(
+            changed=self.changed,
+            msg=self.msg
+        )
+
+
+def main():
+    v = IBMSVProvisioningPolicy()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log('Exception in apply(): \n%s', format_exc())
+        v.module.fail_json(msg='Module failed. Error [%s].' % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_sv_manage_replication_policy.py
+++ b/plugins/modules/ibm_sv_manage_replication_policy.py
@@ -1,0 +1,336 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ibm_sv_manage_replication_policy
+short_description: This module configures and manages replication policies on IBM Spectrum Virtualize family storage systems
+version_added: '1.10.0'
+description:
+  - Ansible interface to manage mkreplicationpolicy, chreplicationpolicy, and rmreplicationpolicy commands.
+  - This module manages policy based replication.
+  - This module can be run on all IBM Spectrum Virtualize storage systems with version 8.5.2.1 or later.
+options:
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    state:
+        description:
+            - Creates, updates (C(present)), or deletes (C(absent)) a replication policy.
+        choices: [ present, absent ]
+        required: true
+        type: str
+    name:
+        description:
+            - Specifies the name of the replication policy.
+        type: str
+        required: true
+    topology:
+        description:
+            - Specifies the policy topology.
+        choices: [ 2-site-async-dr ]
+        type: str
+    location1system:
+        description:
+            - Specifies the name or ID of the system in location 1 of the topology.
+        type: str
+    location1iogrp:
+        description:
+            - Specifies the ID of the I/O group of the system in location 1 of the topology.
+        type: int
+    location2system:
+        description:
+            - Specifies the name or ID of the system in location 2 of the topology.
+        type: str
+    location2iogrp:
+        description:
+            - Specifies the ID of the I/O group of the system in location 2 of the topology.
+        type: int
+    rpoalert:
+        description:
+            - Specifies the RPO alert threshold in seconds.
+              The minimum value is 60 (1 minute) and the maximum value is 86400 (1 day).
+            - The value must be a multiple of 60 seconds.
+        type: int
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+author:
+    - Sanjaikumaar M (@sanjaikumaar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Create replication policy
+  ibm.spectrum_virtualize.ibm_sv_manage_replication_policy:
+    clustername: "{{cluster}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    name: replication_policy0
+    topology: 2-site-async-dr
+    location1system: x.x.x.x
+    location1iogrp: 0
+    location2system: x.x.x.x
+    location2iogrp: 0
+    rpoalert: 60
+    state: present
+- name: Delete replication policy
+  ibm.spectrum_virtualize.ibm_sv_manage_replication_policy:
+    clustername: "{{cluster}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    name: replication_policy0
+    state: absent
+'''
+
+RETURN = '''#'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import (
+    IBMSVCRestApi, svc_argument_spec,
+    get_logger
+)
+from ansible.module_utils._text import to_native
+
+
+class IBMSVReplicationPolicy:
+
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                name=dict(
+                    type='str',
+                    required=True
+                ),
+                state=dict(
+                    type='str',
+                    choices=['present', 'absent'],
+                    required=True
+                ),
+                topology=dict(
+                    type='str',
+                    choices=['2-site-async-dr']
+                ),
+                location1system=dict(
+                    type='str',
+                ),
+                location1iogrp=dict(
+                    type='int',
+                ),
+                location2system=dict(
+                    type='str',
+                ),
+                location2iogrp=dict(
+                    type='int',
+                ),
+                rpoalert=dict(
+                    type='int',
+                )
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # Required parameters
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional parameters
+        self.topology = self.module.params.get('topology', '')
+        self.location1system = self.module.params.get('location1system', '')
+        self.location1iogrp = self.module.params.get('location1iogrp', '')
+        self.location2system = self.module.params.get('location2system', '')
+        self.location2iogrp = self.module.params.get('location2iogrp', '')
+        self.rpoalert = self.module.params.get('rpoalert', '')
+
+        self.basic_checks()
+
+        # logging setup
+        self.log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, self.log_path)
+        self.log = log.info
+
+        # Dynamic variables
+        self.changed = False
+        self.msg = ''
+        self.rp_data = {}
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=self.log_path,
+            token=self.module.params['token']
+        )
+
+    def basic_checks(self):
+        if not self.name:
+            self.module.fail_json(
+                msg='Missing mandatory parameter: name'
+            )
+
+        if self.state == 'absent':
+            invalids = ('topology', 'location1system', 'location1iogrp', 'location2system', 'location2iogrp', 'rpoalert')
+            invalid_exists = ', '.join((var for var in invalids if not getattr(self, var) in {'', None}))
+
+            if invalid_exists:
+                self.module.fail_json(
+                    msg='state=absent but following paramters have been passed: {0}'.format(invalid_exists)
+                )
+
+    def is_rp_exists(self):
+        result = {}
+        cmd = 'lsreplicationpolicy'
+        data = self.restapi.svc_obj_info(cmd=cmd, cmdopts=None, cmdargs=[self.name])
+
+        if isinstance(data, list):
+            for d in data:
+                result.update(d)
+        else:
+            result = data
+
+        self.rp_data = result
+
+        return result
+
+    def create_replication_policy(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'mkreplicationpolicy'
+        cmdopts = {
+            'name': self.name,
+            'topology': self.topology,
+            'location1system': self.location1system,
+            'location1iogrp': self.location1iogrp,
+            'location2system': self.location2system,
+            'location2iogrp': self.location2iogrp,
+            'rpoalert': self.rpoalert,
+        }
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        self.log('Replication policy (%s) created', self.name)
+        self.changed = True
+
+    def replication_policy_probe(self):
+        field_mappings = (
+            ('topology', self.rp_data.get('topology', '')),
+            ('location1system', (
+                ('location1_system_name', self.rp_data.get('location1_system_name', '')),
+                ('location1_system_id', self.rp_data.get('location1_system_id', ''))
+            )),
+            ('location1iogrp', self.rp_data.get('location1_iogrp_id', '')),
+            ('location2system', (
+                ('location2_system_name', self.rp_data.get('location2_system_name', '')),
+                ('location2_system_id', self.rp_data.get('location2_system_id', ''))
+            )),
+            ('location2iogrp', self.rp_data.get('location2_iogrp_id', '')),
+            ('rpoalert', self.rp_data.get('rpo_alert', ''))
+        )
+
+        self.log('replication policy probe data: %s', field_mappings)
+        for f, v in field_mappings:
+            current_value = str(getattr(self, f))
+            if current_value and f in {'location1system', 'location2system'}:
+                try:
+                    next(iter(filter(lambda val: val[1] == current_value, v)))
+                except StopIteration:
+                    self.module.fail_json(
+                        msg='Policy modification is not supported. '
+                            'Please delete and recreate new policy.'
+                    )
+            elif current_value and current_value != v:
+                self.module.fail_json(
+                    msg='Policy modification is not supported. '
+                        'Please delete and recreate new policy.'
+                )
+
+    def delete_replication_policy(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'rmreplicationpolicy'
+        self.restapi.svc_run_command(cmd, cmdopts=None, cmdargs=[self.name])
+        self.log('Replication policy (%s) deleted', self.name)
+        self.changed = True
+
+    def apply(self):
+        if self.is_rp_exists():
+            if self.state == 'present':
+                self.replication_policy_probe()
+                self.msg = 'Replication policy ({0}) already exists. No modifications done.'.format(self.name)
+            else:
+                self.delete_replication_policy()
+                self.msg = 'Replication policy ({0}) deleted'.format(self.name)
+        else:
+            if self.state == 'absent':
+                self.msg = 'Replication policy ({0}) does not exists.'.format(self.name)
+            else:
+                self.create_replication_policy()
+                self.msg = 'Replication policy ({0}) created.'.format(self.name)
+
+        if self.module.check_mode:
+            self.msg = 'skipping changes due to check mode.'
+
+        self.module.exit_json(
+            changed=self.changed,
+            msg=self.msg
+        )
+
+
+def main():
+    v = IBMSVReplicationPolicy()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log('Exception in apply(): \n%s', format_exc())
+        v.module.fail_json(msg='Module failed. Error [%s].' % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_sv_manage_snapshotpolicy.py
+++ b/plugins/modules/ibm_sv_manage_snapshotpolicy.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2022 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/plugins/modules/ibm_sv_manage_truststore_for_replication.py
+++ b/plugins/modules/ibm_sv_manage_truststore_for_replication.py
@@ -1,0 +1,399 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ibm_sv_manage_truststore_for_replication
+short_description: This module manages certificate trust stores for replication on
+                   IBM Spectrum Virtualize family storage systems
+version_added: '1.10.0'
+description:
+  - Ansible interface to manage mktruststore and rmtruststore commands.
+  - This module transfers the certificate from a remote system to the local system.
+  - This module works on SSH and uses paramiko to establish an SSH connection.
+  - Once transfer is done successfully, it also adds the certificate to the trust store of the local system.
+  - This module can be used to set up mutual TLS (mTLS) for policy-based replication inter-system communication
+    using cluster endpoint certificates (usually system-signed which are exported by the
+    M(ibm.spectrum_virtualize.ibm_sv_manage_SSL_certificate) module).
+options:
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    username:
+        description:
+            - Username for the Spectrum Virtualize storage system.
+        type: str
+        required: true
+    password:
+        description:
+            - Password for the Spectrum Virtualize storage system.
+            - Mandatory, when I(usesshkey=no).
+        type: str
+    usesshkey:
+        description:
+            - For key-pair based SSH connection, set this field as "yes".
+              Provide full path of key in key_filename field.
+              If not provided, default path of SSH key is used.
+        type: str
+        choices: [ 'yes', 'no']
+        default: 'no'
+    key_filename:
+        description:
+            - SSH client private key filename. By default, ~/.ssh/id_rsa is used.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    state:
+        description:
+            - Creates (C(present)) or deletes (C(absent)) a trust store.
+        choices: [ present, absent ]
+        required: true
+        type: str
+    name:
+        description:
+            - Specifies the name of the trust store.
+            - If not specified, the module generates a name automatically with format store_I(remote_clustername).
+        type: str
+    remote_clustername:
+        description:
+            - Specifies the name of the partner remote cluster with which mTLS partnership needs to be setup.
+        type: str
+        required: true
+    remote_username:
+        description:
+            - Username for remote cluster.
+            - Applies when I(state=present) to create a trust store.
+        type: str
+    remote_password:
+        description:
+            - Password for remote cluster.
+            - Applies when I(state=present) to create a trust store.
+        type: str
+author:
+    - Sanjaikumaar M(@sanjaikumaar)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Create truststore
+  ibm.spectrum_virtualize.ibm_sv_manage_truststore_for_replication:
+    clustername: "{{clustername}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    name: "{{name}}"
+    remote_clustername: "{{remote_clustername}}"
+    remote_username: "{{remote_username}}"
+    remote_password: "{{remote_password}}"
+    log_path: "{{log_path}}"
+    state: "present"
+- name: Delete truststore
+  ibm.spectrum_virtualize.ibm_sv_manage_truststore_for_replication:
+    clustername: "{{clustername}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    name: "{{name}}"
+    remote_clustername: "{{remote_clustername}}"
+    log_path: "{{log_path}}"
+    state: "absent"
+'''
+
+RETURN = '''#'''
+
+from traceback import format_exc
+import json
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import (
+    svc_ssh_argument_spec,
+    get_logger
+)
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_ssh import IBMSVCssh
+from ansible.module_utils._text import to_native
+
+
+class IBMSVTrustStore:
+
+    def __init__(self):
+        argument_spec = svc_ssh_argument_spec()
+        argument_spec.update(
+            dict(
+                password=dict(
+                    type='str',
+                    required=False,
+                    no_log=True
+                ),
+                name=dict(
+                    type='str'
+                ),
+                usesshkey=dict(
+                    type='str',
+                    default='no',
+                    choices=['yes', 'no']
+                ),
+                key_filename=dict(
+                    type='str',
+                ),
+                state=dict(
+                    type='str',
+                    choices=['present', 'absent'],
+                    required=True
+                ),
+                remote_clustername=dict(
+                    type='str',
+                    required=True
+                ),
+                remote_username=dict(
+                    type='str',
+                ),
+                remote_password=dict(
+                    type='str',
+                    no_log=True
+                ),
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # logging setup
+        self.log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, self.log_path)
+        self.log = log.info
+
+        # Required parameters
+        self.state = self.module.params['state']
+        self.remote_clustername = self.module.params['remote_clustername']
+
+        # local SSH keys will be used in case of password less SSH connection
+        self.usesshkey = self.module.params['usesshkey']
+        self.key_filename = self.module.params['key_filename']
+
+        # Optional parameters
+        self.password = self.module.params.get('password', '')
+        self.name = self.module.params.get('name', '')
+        self.remote_username = self.module.params.get('remote_username', '')
+        self.remote_password = self.module.params.get('remote_password', '')
+
+        if not self.name:
+            self.name = 'store_{0}'.format(self.remote_clustername)
+
+        if not self.password:
+            if self.usesshkey == 'yes':
+                self.log("password is none and use ssh private key. Check for its path")
+                if self.key_filename:
+                    self.log("key file_name is provided, use it")
+                    self.look_for_keys = True
+                else:
+                    self.log("key file_name is not provided, use default one, ~/.ssh/id_rsa.pub")
+                    self.look_for_keys = True
+            else:
+                self.log("password is none and SSH key is not provided")
+                self.module.fail_json(msg="You must pass either password or usesshkey parameter.")
+        else:
+            self.log("password is given")
+            self.look_for_keys = False
+
+        self.basic_checks()
+
+        # Dynamic variables
+        self.changed = False
+        self.msg = ''
+
+        self.ssh_client = IBMSVCssh(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            username=self.module.params['username'],
+            password=self.password,
+            look_for_keys=self.look_for_keys,
+            key_filename=self.key_filename,
+            log_path=self.log_path
+        )
+
+    def basic_checks(self):
+        if self.state == 'present':
+            if not self.remote_clustername:
+                self.module.fail_json(
+                    msg='Missing mandatory parameter: remote_clustername'
+                )
+            if not self.remote_username:
+                self.module.fail_json(
+                    msg='Missing mandatory parameter: remote_username'
+                )
+            if not self.remote_password:
+                self.module.fail_json(
+                    msg='Missing mandatory parameter: remote_password'
+                )
+        elif self.state == 'absent':
+            if not self.remote_clustername:
+                self.module.fail_json(
+                    msg='Missing mandatory parameter: remote_clustername'
+                )
+
+            unsupported = ('remote_username', 'remote_password')
+            unsupported_exists = ', '.join((field for field in unsupported if getattr(self, field)))
+            if unsupported_exists:
+                self.module.fail_json(
+                    msg='state=absent but following paramters have been passed: {0}'.format(unsupported_exists)
+                )
+
+    def raise_error(self, stderr):
+        message = stderr.read().decode('utf-8')
+        if len(message) > 0:
+            self.log("%s", message)
+            self.module.fail_json(msg=message)
+        else:
+            message = 'Unknown error received.'
+            self.module.fail_json(msg=message)
+
+    def is_truststore_exists(self):
+        merged_result = {}
+        cmd = 'lstruststore -json {0}'.format(self.name)
+        stdin, stdout, stderr = self.ssh_client.client.exec_command(cmd)
+        result = stdout.read().decode('utf-8')
+
+        if result:
+            result = json.loads(result)
+        else:
+            return merged_result
+
+        rc = stdout.channel.recv_exit_status()
+        if rc > 0:
+            message = stderr.read().decode('utf-8')
+            if (message.count('CMMVC5804E') != 1) or (message.count('CMMVC6035E') != 1):
+                self.log("Error in executing CLI command: %s", cmd)
+                self.log("%s", message)
+                self.module.fail_json(msg=message)
+            else:
+                self.log("Expected error: %s", message)
+
+        if isinstance(result, list):
+            for d in result:
+                merged_result.update(d)
+        else:
+            merged_result = result
+
+        return merged_result
+
+    def download_file(self):
+        if self.module.check_mode:
+            return
+
+        cmd = 'scp -o stricthostkeychecking=no {0}@{1}:/dumps/certificate.pem /upgrade/'.format(
+            self.remote_username,
+            self.remote_clustername
+        )
+        self.log('Command to be executed: %s', cmd)
+        stdin, stdout, stderr = self.ssh_client.client.exec_command(cmd, get_pty=True, timeout=60 * 1.5)
+        result = ''
+        while not stdout.channel.recv_ready():
+            data = stdout.channel.recv(1024)
+            self.log(str(data, 'utf-8'))
+            if data:
+                if b'Password:' in data or b'password' in data:
+                    stdin.write("{0}\n".format(self.remote_password))
+                    stdin.flush()
+                else:
+                    result += data.decode('utf-8')
+                break
+
+        result += stdout.read().decode('utf-8')
+        rc = stdout.channel.recv_exit_status()
+        if rc > 0:
+            message = stderr.read().decode('utf-8')
+            self.log("Error in executing command: %s", cmd)
+            if not len(message) > 1:
+                if len(result) > 1:
+                    err = result.replace('\rPassword:\r\n', '')
+                    self.log("Error: %s", err)
+                    if err:
+                        self.module.fail_json(msg=err)
+                self.module.fail_json(msg='Unknown error received')
+            else:
+                self.module.fail_json(msg=message)
+        else:
+            self.log(result)
+
+    def create_truststore(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'mktruststore -name {0} -file {1}'.format(self.name, '/upgrade/certificate.pem')
+        self.log('Command to be executed: %s', cmd)
+        stdin, stdout, stderr = self.ssh_client.client.exec_command(cmd)
+        result = stdout.read().decode('utf-8')
+        rc = stdout.channel.recv_exit_status()
+
+        if rc > 0:
+            self.log("Error in executing command: %s", cmd)
+            self.raise_error(stderr)
+        else:
+            self.log('Truststore (%s) created', self.name)
+            self.changed = True
+
+    def delete_truststore(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        cmd = 'rmtruststore {0}'.format(self.name)
+        self.log('Command to be executed: %s', cmd)
+        stdin, stdout, stderr = self.ssh_client.client.exec_command(cmd)
+        result = stdout.read().decode('utf-8')
+        rc = stdout.channel.recv_exit_status()
+
+        if rc > 0:
+            self.log("Error in executing command: %s", cmd)
+            self.raise_error(stderr)
+        else:
+            self.log('Truststore (%s) deleted', self.name)
+            self.changed = True
+
+    def apply(self):
+        if self.is_truststore_exists():
+            self.log("Truststore (%s) exists", self.name)
+            if self.state == 'present':
+                self.msg = 'Truststore ({0}) already exist. No modifications done'.format(self.name)
+            else:
+                self.delete_truststore()
+                self.msg = 'Truststore ({0}) deleted.'.format(self.name)
+        else:
+            if self.state == 'absent':
+                self.msg = 'Truststore ({0}) does not exist. No modifications done.'.format(self.name)
+            else:
+                self.download_file()
+                self.create_truststore()
+                self.msg = 'Truststore ({0}) created.'.format(self.name)
+
+        if self.module.check_mode:
+            self.msg = 'skipping changes due to check mode.'
+
+        self.module.exit_json(
+            changed=self.changed,
+            msg=self.msg
+        )
+
+
+def main():
+    v = IBMSVTrustStore()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log('Exception in apply(): \n%s', format_exc())
+        v.module.fail_json(msg='Module failed. Error [%s].' % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_sv_switch_replication_direction.py
+++ b/plugins/modules/ibm_sv_switch_replication_direction.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ibm_sv_switch_replication_direction
+short_description: This module switches the replication direction on IBM Spectrum Virtualize family storage systems
+version_added: '1.10.0'
+description:
+  - Ansible interface to manage the chvolumegroupreplication command.
+  - This module can be used to switch replication direction.
+options:
+    clustername:
+        description:
+            - The hostname or management IP of the Spectrum Virtualize storage system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Spectrum Virtualize storage system.
+            - Valid when the hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Spectrum Virtualize storage system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Spectrum Virtualize storage system.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    name:
+        description:
+            - Specifies the name of the volume group.
+        type: str
+        required: true
+    mode:
+        description:
+            - Specifies the replication mode of the volume group.
+        choices: [ independent, production ]
+        required: true
+        type: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+author:
+    - Shilpi Jain(@Shilpi-J)
+notes:
+    - This module supports C(check_mode).
+'''
+
+EXAMPLES = '''
+- name: Switch to independent mode
+  ibm.spectrum_virtualize.ibm_sv_switch_replication_direction:
+    clustername: "{{ clustername }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    mode: independent
+    name: vg0
+'''
+
+RETURN = '''#'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import (
+    IBMSVCRestApi, svc_argument_spec,
+    get_logger
+)
+from ansible.module_utils._text import to_native
+
+
+class IBMSVSwitchReplication:
+
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+        argument_spec.update(
+            dict(
+                name=dict(
+                    type='str',
+                    required=True
+                ),
+                mode=dict(
+                    type='str',
+                    choices=['independent', 'production'],
+                    required=True
+                )
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # Required parameters
+        self.name = self.module.params['name']
+        self.mode = self.module.params['mode']
+
+        self.basic_checks()
+
+        # logging setup
+        self.log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, self.log_path)
+        self.log = log.info
+
+        # Dynamic variables
+        self.changed = False
+        self.msg = ''
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=self.log_path,
+            token=self.module.params['token']
+        )
+
+    def basic_checks(self):
+        if not self.name:
+            self.module.fail_json(
+                msg='Missing mandatory parameter: name'
+            )
+
+    # function to check whether volume group exists or not
+    def get_volumegroup_info(self):
+        return self.restapi.svc_obj_info(
+            'lsvolumegroup', None, [self.name]
+        )
+
+    def change_vg_mode(self):
+        cmd = 'chvolumegroupreplication'
+        cmdopts = {}
+        cmdopts["mode"] = self.mode
+        self.log("Changing replicaiton direction.. Command %s opts %s", cmd, cmdopts)
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=[self.name])
+
+    def apply(self):
+        if self.module.check_mode:
+            self.msg = 'skipping changes due to check mode.'
+        else:
+            if self.get_volumegroup_info():
+                self.change_vg_mode()
+                self.changed = True
+                self.msg = "Replication direction on volume group [%s] has been modified." % self.name
+            else:
+                self.module.fail_json(msg="Volume group does not exist: [%s]" % self.name)
+
+        self.module.exit_json(
+            changed=self.changed,
+            msg=self.msg
+        )
+
+
+def main():
+    v = IBMSVSwitchReplication()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log('Exception in apply(): \n%s', format_exc())
+        v.module.fail_json(msg='Module failed. Error [%s].' % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_svc_host.py
+++ b/plugins/modules/ibm_svc_host.py
@@ -6,8 +6,7 @@
 #            Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
 #            Rohit Kumar <rohit.kumar6@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -54,7 +53,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
         version_added: '1.5.0'
     fcwwpn:

--- a/plugins/modules/ibm_svc_hostcluster.py
+++ b/plugins/modules/ibm_svc_hostcluster.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2021 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -52,7 +51,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
     ownershipgroup:
         description:

--- a/plugins/modules/ibm_svc_initial_setup.py
+++ b/plugins/modules/ibm_svc_initial_setup.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2021 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -41,7 +40,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
     log_path:
         description:

--- a/plugins/modules/ibm_svc_manage_consistgrp_flashcopy.py
+++ b/plugins/modules/ibm_svc_manage_consistgrp_flashcopy.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2021 IBM CORPORATION
 # Author(s): Sreshtant Bohidar <sreshtant.bohidar@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -53,7 +52,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
         version_added: '1.5.0'
     ownershipgroup:

--- a/plugins/modules/ibm_svc_manage_ownershipgroup.py
+++ b/plugins/modules/ibm_svc_manage_ownershipgroup.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2021 IBM CORPORATION
 # Author(s): Sanjaikumaar <sanjaikumaar.m@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
@@ -53,7 +52,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
     keepobjects:
         description:

--- a/plugins/modules/ibm_svc_manage_portset.py
+++ b/plugins/modules/ibm_svc_manage_portset.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2022 IBM CORPORATION
 # Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -41,7 +40,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
     log_path:
         description:

--- a/plugins/modules/ibm_svc_manage_safeguarded_policy.py
+++ b/plugins/modules/ibm_svc_manage_safeguarded_policy.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2022 IBM CORPORATION
 # Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -42,7 +41,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
     log_path:
         description:

--- a/plugins/modules/ibm_svc_manage_sra.py
+++ b/plugins/modules/ibm_svc_manage_sra.py
@@ -4,8 +4,7 @@
 # Copyright (C) 2021 IBM CORPORATION
 # Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -41,7 +40,7 @@ options:
     token:
         description:
             - The authentication token to verify a user on the Spectrum Virtualize storage system.
-            - To generate a token, use the ibm_svc_auth module.
+            - To generate a token, use the M(ibm.spectrum_virtualize.ibm_svc_auth) module.
         type: str
     log_path:
         description:

--- a/plugins/modules/ibm_svc_manage_volume.py
+++ b/plugins/modules/ibm_svc_manage_volume.py
@@ -654,6 +654,7 @@ class IBMSVCvolume(object):
                 else:
                     msg = "volume [%s] already exists." % self.name
         if self.module.check_mode:
+            msg = 'Skipping changes due to check mode.'
             self.log('skipping changes due to check mode.')
 
         self.module.exit_json(msg=msg, changed=self.changed)

--- a/plugins/modules/ibm_svcinfo_command.py
+++ b/plugins/modules/ibm_svcinfo_command.py
@@ -2,8 +2,7 @@
 # Copyright (C) 2020 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 #
-# GNU General Public License v3.0+
-# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -59,8 +58,6 @@ options:
     description:
     - Path of debug log file.
     type: str
-notes:
-    - This module supports C(check_mode).
 '''
 
 EXAMPLES = '''

--- a/tests/unit/plugins/modules/test_ibm_sv_manage_SSL_certificate.py
+++ b/tests/unit/plugins/modules/test_ibm_sv_manage_SSL_certificate.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_sv_manage_snapshot """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_sv_manage_SSL_certificate import IBMSVSSLCertificate
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVSSLCertificate(unittest.TestCase):
+    """
+    Group of related Unit Tests
+    """
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_module_export_certificate(self, svc_authorize_mock, svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'certificate_type': 'system'
+        })
+
+        cert = IBMSVSSLCertificate()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            cert.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+        self.assertEqual(svc_run_command_mock.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_sv_manage_provisioning_policy.py
+++ b/tests/unit/plugins/modules/test_ibm_sv_manage_provisioning_policy.py
@@ -1,0 +1,370 @@
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_sv_manage_provisioning_policy """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_sv_manage_provisioning_policy import IBMSVProvisioningPolicy
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVProvisioningPolicy(unittest.TestCase):
+    """
+    Group of related Unit Tests
+    """
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def test_module_with_blank_values(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': ''
+        })
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVProvisioningPolicy()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_without_state_parameter(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp0',
+        })
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVProvisioningPolicy()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_provisioning_policy.IBMSVProvisioningPolicy.is_pp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_without_mandatory_parameter(self,
+                                                svc_authorize_mock,
+                                                svc_run_command_mock,
+                                                pp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp0',
+            'state': 'present'
+        })
+
+        pp_exists_mock.return_value = {}
+        pp = IBMSVProvisioningPolicy()
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            pp.apply()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_provisioning_policy.IBMSVProvisioningPolicy.is_pp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_provisioning_policy(self,
+                                        svc_authorize_mock,
+                                        svc_run_command_mock,
+                                        pp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp0',
+            'capacitysaving': 'drivebased',
+            'state': 'present'
+        })
+
+        pp_exists_mock.return_value = {}
+        pp = IBMSVProvisioningPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            pp.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_provisioning_policy_idempotency(self,
+                                                    svc_authorize_mock,
+                                                    svc_obj_info_mock,
+                                                    svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp0',
+            'capacitysaving': 'drivebased',
+            'state': 'present'
+        })
+
+        svc_obj_info_mock.return_value = {'id': 0, 'name': 'pp0', 'capacity_saving': 'none'}
+        pp = IBMSVProvisioningPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            pp.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_provisioning_policy.IBMSVProvisioningPolicy.is_pp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_rename_provisioning_policy(self,
+                                        svc_authorize_mock,
+                                        svc_run_command_mock,
+                                        pp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp_new',
+            'old_name': 'pp0',
+            'state': 'present'
+        })
+
+        pp_exists_mock.side_effect = iter([
+            {'id': 0, 'name': 'pp0'},
+            {},
+            {'id': 0, 'name': 'pp0'}
+        ])
+        pp = IBMSVProvisioningPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            pp.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_provisioning_policy.IBMSVProvisioningPolicy.is_pp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_rename_provisioning_policy_idempotency(self,
+                                                    svc_authorize_mock,
+                                                    svc_run_command_mock,
+                                                    pp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp_new',
+            'old_name': 'pp0',
+            'state': 'present'
+        })
+
+        pp_exists_mock.side_effect = iter([{}, {'id': 0, 'name': 'pp0'}, {}])
+        pp = IBMSVProvisioningPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            pp.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_with_capacitysaving(self,
+                                        svc_authorize_mock,
+                                        svc_run_command_mock,
+                                        svc_obj_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp_new',
+            'old_name': 'pp0',
+            'capacitysaving': 'drivebased',
+            'state': 'present'
+        })
+
+        svc_obj_info_mock.return_value = {'id': 0, 'name': 'pp0', 'capacity_saving': 'none'}
+        pp = IBMSVProvisioningPolicy()
+        with pytest.raises(AnsibleFailJson) as exc:
+            pp.apply()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_with_deduplicated(self,
+                                      svc_authorize_mock,
+                                      svc_run_command_mock,
+                                      svc_obj_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp_new',
+            'old_name': 'pp0',
+            'deduplicated': True,
+            'state': 'present'
+        })
+
+        svc_obj_info_mock.return_value = {'id': 0, 'name': 'pp0', 'deduplicated': 'no'}
+        pp = IBMSVProvisioningPolicy()
+        with pytest.raises(AnsibleFailJson) as exc:
+            pp.apply()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_provisioning_policy.IBMSVProvisioningPolicy.is_pp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_delete_provisioning_policy(self,
+                                        svc_authorize_mock,
+                                        svc_run_command_mock,
+                                        pp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp0',
+            'state': 'absent'
+        })
+
+        pp_exists_mock.return_value = {'id': 0, 'name': 'pp0'}
+        pp = IBMSVProvisioningPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            pp.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_provisioning_policy.IBMSVProvisioningPolicy.is_pp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_delete_provisioning_policy_idempotency(self,
+                                                    svc_authorize_mock,
+                                                    svc_run_command_mock,
+                                                    pp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp0',
+            'state': 'absent'
+        })
+
+        pp_exists_mock.return_value = {}
+        pp = IBMSVProvisioningPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            pp.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_provisioning_policy.IBMSVProvisioningPolicy.is_pp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_delete_provisioning_policy_validation(self,
+                                                   svc_authorize_mock,
+                                                   svc_run_command_mock,
+                                                   pp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'pp0',
+            'capacitysaving': 'drivebased',
+            'state': 'absent'
+        })
+
+        pp_exists_mock.return_value = {}
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVProvisioningPolicy()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_sv_manage_replication_policy.py
+++ b/tests/unit/plugins/modules/test_ibm_sv_manage_replication_policy.py
@@ -1,0 +1,317 @@
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_sv_manage_replication_policy """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_sv_manage_replication_policy import IBMSVReplicationPolicy
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVReplicationPolicy(unittest.TestCase):
+    """
+    Group of related Unit Tests
+    """
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def test_module_with_blank_values(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': ''
+        })
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVReplicationPolicy()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_without_state_parameter(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+        })
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVReplicationPolicy()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_replication_policy.IBMSVReplicationPolicy.is_rp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_without_mandatory_parameter(self,
+                                                svc_authorize_mock,
+                                                svc_run_command_mock,
+                                                rp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+            'state': 'present'
+        })
+
+        rp_exists_mock.return_value = {}
+        svc_run_command_mock.side_effect = fail_json
+        rp = IBMSVReplicationPolicy()
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            rp.apply()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_replication_policy.IBMSVReplicationPolicy.is_rp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_replication_policy(self,
+                                       svc_authorize_mock,
+                                       svc_run_command_mock,
+                                       rp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+            'topology': '2-site-async-dr',
+            'location1system': 'cluster_A',
+            'location1iogrp': 0,
+            'location2system': 'cluster_B',
+            'location2iogrp': 0,
+            'rpoalert': 60,
+            'state': 'present'
+        })
+
+        rp_exists_mock.return_value = {}
+        rp = IBMSVReplicationPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            rp.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_replication_policy_idempotency(self,
+                                                   svc_authorize_mock,
+                                                   svc_run_command_mock,
+                                                   svc_obj_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+            'topology': '2-site-async-dr',
+            'location1system': 'cluster_A',
+            'location1iogrp': 0,
+            'location2system': 'cluster_B',
+            'location2iogrp': 0,
+            'rpoalert': 60,
+            'state': 'present'
+        })
+
+        svc_obj_info_mock.return_value = {
+            'id': 0,
+            'name': 'rp0',
+            'topology': '2-site-async-dr',
+            'location1_system_name': 'cluster_A',
+            'location1_iogrp_id': '0',
+            'location2_system_name': 'cluster_B',
+            'location2_iogrp_id': '0',
+            'rpo_alert': '60',
+        }
+        rp = IBMSVReplicationPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            rp.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_replication_policy(self,
+                                       svc_authorize_mock,
+                                       svc_run_command_mock,
+                                       svc_obj_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+            'location1system': 'cluster_C',
+            'state': 'present'
+        })
+
+        svc_obj_info_mock.return_value = {
+            'id': 0,
+            'name': 'rp0',
+            'location1_system_name': 'cluster_A'
+        }
+        rp = IBMSVReplicationPolicy()
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            rp.apply()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_replication_policy.IBMSVReplicationPolicy.is_rp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_delete_replication_policy(self,
+                                       svc_authorize_mock,
+                                       svc_run_command_mock,
+                                       rp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+            'state': 'absent'
+        })
+
+        rp_exists_mock.return_value = {
+            'id': 0,
+            'name': 'rp0'
+        }
+        rp = IBMSVReplicationPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            rp.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_replication_policy.IBMSVReplicationPolicy.is_rp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_delete_replication_policy_idempotency(self,
+                                                   svc_authorize_mock,
+                                                   svc_run_command_mock,
+                                                   rp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+            'state': 'absent'
+        })
+
+        rp_exists_mock.return_value = {}
+        rp = IBMSVReplicationPolicy()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            rp.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_manage_replication_policy.IBMSVReplicationPolicy.is_rp_exists')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_delete_replication_policy_validation(self,
+                                                  svc_authorize_mock,
+                                                  svc_run_command_mock,
+                                                  rp_exists_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'rp0',
+            'topology': '2-site-async-dr',
+            'location1system': 'cluster_A',
+            'location1iogrp': '0',
+            'location2system': 'cluster_B',
+            'location2iogrp': '0',
+            'rpoalert': 60,
+            'state': 'absent'
+        })
+
+        rp_exists_mock.return_value = {'id': 0, 'name': 'rp0'}
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVReplicationPolicy()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_sv_manage_truststore_for_replication.py
+++ b/tests/unit/plugins/modules/test_ibm_sv_manage_truststore_for_replication.py
@@ -1,0 +1,324 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Sanjaikumaar M <sanjaikumaar.m@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_sv_manage_truststore_for_replication """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch, Mock
+from ansible.module_utils.compat.paramiko import paramiko
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_ssh import IBMSVCssh
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_sv_manage_truststore_for_replication import (
+    IBMSVTrustStore
+)
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module
+    creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVTrustStore(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+
+    def test_module_mandatory_parameter(self):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'state': 'present'
+        })
+
+        with pytest.raises(AnsibleFailJson) as exc:
+            IBMSVTrustStore()
+        self.assertTrue(exc.value.args[0]['failed'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_create_truststore_with_name(self, svc_connect_mock, ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansi_store',
+            'remote_clustername': 'x.x.x.x',
+            'remote_username': 'remote_username',
+            'remote_password': 'remote_password',
+            'state': 'present'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+        self.assertTrue('ansi_store' in exc.value.args[0]['msg'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_create_truststore_with_name_idempotency(self,
+                                                            svc_connect_mock,
+                                                            ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansi_store',
+            'remote_clustername': 'x.x.x.x',
+            'remote_username': 'remote_username',
+            'remote_password': 'remote_password',
+            'state': 'present'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{"name":"ansi_store"}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_create_truststore_without_name(self, svc_connect_mock,
+                                                   ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'remote_clustername': 'x.x.x.x',
+            'remote_username': 'remote_username',
+            'remote_password': 'remote_password',
+            'state': 'present'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+        self.assertTrue('store_x.x.x.x' in exc.value.args[0]['msg'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_create_truststore_without_name_idempotency(self, svc_connect_mock,
+                                                               ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'remote_clustername': 'x.x.x.x',
+            'remote_username': 'remote_username',
+            'remote_password': 'remote_password',
+            'state': 'present'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{"name": "store_x.x.x.x"}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_delete_truststore_with_name(self, svc_connect_mock,
+                                                ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'name': 'ansi_store',
+            'remote_clustername': 'x.x.x.x',
+            'state': 'absent'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{"name": "ansi_store"}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_delete_truststore_with_name_idempotency(self, svc_connect_mock,
+                                                            ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'remote_clustername': 'x.x.x.x',
+            'state': 'absent'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+        self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_delete_truststore_without_name(self, svc_connect_mock,
+                                                   ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'remote_clustername': 'x.x.x.x',
+            'state': 'absent'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{"name": "store_x.x.x.x"}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+
+        self.assertTrue(exc.value.args[0]['changed'])
+        self.assertTrue('store_x.x.x.x' in exc.value.args[0]['msg'])
+
+    @patch('ansible.module_utils.compat.paramiko.paramiko.SSHClient')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.'
+           'module_utils.ibm_svc_ssh.IBMSVCssh._svc_connect')
+    def test_module_delete_truststore_without_name_idempotency(self, svc_connect_mock,
+                                                               ssh_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'username': 'username',
+            'password': 'password',
+            'remote_clustername': 'x.x.x.x',
+            'state': 'absent'
+        })
+        con_mock = Mock()
+        svc_connect_mock.return_value = True
+        ssh_mock.return_value = con_mock
+        stdin = Mock()
+        stdout = Mock()
+        stderr = Mock()
+        con_mock.exec_command.return_value = (stdin, stdout, stderr)
+        stdout.read.side_effect = iter([br'{}', b'', b''])
+        stdout.channel.recv_exit_status.return_value = 0
+
+        ts = IBMSVTrustStore()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            ts.apply()
+
+        self.assertFalse(exc.value.args[0]['changed'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_sv_switch_replication_direction.py
+++ b/tests/unit/plugins/modules/test_ibm_sv_switch_replication_direction.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2022 IBM CORPORATION
+# Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Spectrum Virtualize Ansible module: ibm_sv_switch_replication_direction """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.spectrum_virtualize.plugins.modules.ibm_sv_switch_replication_direction import IBMSVSwitchReplication
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module creation """
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVSwitchReplication(unittest.TestCase):
+    """ a group of related Unit Tests"""
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def set_default_args(self):
+        return dict({
+            'name': 'test',
+            'mode': 'independent'
+        })
+
+    def test_module_fail_when_required_args_missing(self):
+        """ required arguments are reported as errors """
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({})
+            IBMSVSwitchReplication()
+        print('Info: %s' % exc.value.args[0]['msg'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_change_mode(self, svc_authorize_mock, svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_name',
+            'mode': 'independent',
+        })
+        svc_run_command_mock.return_value = ''
+        obj = IBMSVSwitchReplication()
+        return_data = obj.change_vg_mode()
+        self.assertEqual(None, return_data)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_switch_replication_direction.IBMSVSwitchReplication.get_volumegroup_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_failure_nonexistent_volumegroup(self, svc_authorize_mock, svc_run_command_mock, get_volumegroup_info_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_name',
+            'mode': 'independent',
+        })
+        get_volumegroup_info_mock.return_value = {}
+        with pytest.raises(AnsibleFailJson) as exc:
+            obj = IBMSVSwitchReplication()
+            obj.apply()
+        self.assertEqual('Volume group does not exist: [test_name]', exc.value.args[0]['msg'])
+        self.assertEqual(True, exc.value.args[0]['failed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.modules.'
+           'ibm_sv_switch_replication_direction.IBMSVSwitchReplication.change_vg_mode')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_for_failure_with_unsupported_state(self, svc_authorize_mock, svc_run_command_mock, change_vg_mode_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_name',
+            'state': 'wrong_state',
+        })
+        with pytest.raises(AnsibleFailJson) as exc:
+            obj = IBMSVSwitchReplication()
+            obj.apply()
+        self.assertEqual(True, exc.value.args[0]["failed"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_volumegroup.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_volumegroup.py
@@ -105,7 +105,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
         vg.get_existing_vg()
@@ -134,7 +136,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
         probe_data = vg.vg_probe(data)
@@ -164,7 +168,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
         probe_data = vg.vg_probe(data)
@@ -194,7 +200,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
         probe_data = vg.vg_probe(data)
@@ -224,7 +232,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
         probe_data = vg.vg_probe(data)
@@ -254,7 +264,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "old_policy_name",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
         probe_data = vg.vg_probe(data)
@@ -285,12 +297,13 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
-        probe_data = vg.vg_probe(data)
         with pytest.raises(AnsibleFailJson) as exc:
-            vg.vg_update(probe_data)
+            vg.vg_probe(data)
         self.assertTrue(exc.value.args[0]['failed'])
 
     @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
@@ -318,12 +331,13 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
-        probe_data = vg.vg_probe(data)
         with pytest.raises(AnsibleFailJson) as exc:
-            vg.vg_update(probe_data)
+            vg.vg_probe(data)
         self.assertTrue(exc.value.args[0]['failed'])
 
     @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
@@ -351,45 +365,13 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         vg = IBMSVCVG()
-        probe_data = vg.vg_probe(data)
         with pytest.raises(AnsibleFailJson) as exc:
-            vg.vg_update(probe_data)
-        self.assertTrue(exc.value.args[0]['failed'])
-
-    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
-           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
-    def test_failure_for_mutual_exclusive_parameter_4(self, mock_svc_authorize):
-        set_module_args({
-            'clustername': 'clustername',
-            'domain': 'domain',
-            'username': 'username',
-            'password': 'password',
-            'name': 'test_volume',
-            'state': 'present',
-            'noownershipgroup': True,
-            'safeguardpolicyname': 'policy_name'
-        })
-        data = {
-            "id": "8",
-            "name": "test_volumegroup",
-            "volume_count": "0",
-            "backup_status": "empty",
-            "last_backup_time": "",
-            "owner_id": "",
-            "owner_name": "",
-            "safeguarded_policy_id": "",
-            "safeguarded_policy_name": "",
-            "safeguarded_policy_start_time": "",
-            "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
-        }
-        vg = IBMSVCVG()
-        probe_data = vg.vg_probe(data)
-        with pytest.raises(AnsibleFailJson) as exc:
-            vg.vg_update(probe_data)
+            vg.vg_probe(data)
         self.assertTrue(exc.value.args[0]['failed'])
 
     @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
@@ -630,7 +612,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         with pytest.raises(AnsibleExitJson) as exc:
             vg = IBMSVCVG()
@@ -666,7 +650,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         srcm.return_value = None
         with pytest.raises(AnsibleExitJson) as exc:
@@ -703,7 +689,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
         with pytest.raises(AnsibleExitJson) as exc:
             vg = IBMSVCVG()
@@ -749,6 +737,7 @@ class TestIBMSVCvdisk(unittest.TestCase):
             'password': 'password',
             'name': 'test_volumegroup',
             'snapshotpolicy': 'ss_policy1',
+            'replicationpolicy': 'rp0',
             'state': 'present',
         })
         svc_obj_info_mock.return_value = {}
@@ -773,6 +762,7 @@ class TestIBMSVCvdisk(unittest.TestCase):
             'password': 'password',
             'name': 'test_volumegroup',
             'snapshotpolicy': 'ss_policy1',
+            'replicationpolicy': 'rp0',
             'state': 'present',
         })
         svc_obj_info_mock.return_value = {
@@ -787,7 +777,10 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "ss_policy1",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no",
+            "replication_policy_name": "rp0"
         }
         with pytest.raises(AnsibleExitJson) as exc:
             vg = IBMSVCVG()
@@ -800,7 +793,35 @@ class TestIBMSVCvdisk(unittest.TestCase):
            'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
     @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
            'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
-    def test_update_snapshot_policy(self, mock_svc_authorize, svc_obj_info_mock,
+    def test_create_volumegroup_with_safeguarded_snapshotpolicy(self,
+                                                                mock_svc_authorize,
+                                                                svc_obj_info_mock,
+                                                                svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volumegroup',
+            'snapshotpolicy': 'ss_policy1',
+            'safeguarded': True,
+            'ignoreuserfcmaps': 'yes',
+            'state': 'present',
+        })
+        svc_obj_info_mock.return_value = {}
+        with pytest.raises(AnsibleExitJson) as exc:
+            vg = IBMSVCVG()
+            vg.apply()
+        self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_snapshot_policy(self, mock_svc_authorize,
+                                    svc_obj_info_mock,
                                     svc_run_command_mock):
         set_module_args({
             'clustername': 'clustername',
@@ -809,6 +830,7 @@ class TestIBMSVCvdisk(unittest.TestCase):
             'password': 'password',
             'name': 'test_volumegroup',
             'snapshotpolicy': 'ss_policy2',
+            'replicationpolicy': 'rp0',
             'state': 'present',
         })
         data = {
@@ -823,12 +845,59 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "ss_policy1",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no",
+            "replication_policy_name": ""
         }
 
         vg = IBMSVCVG()
         probe_data = vg.vg_probe(data)
         self.assertTrue('snapshotpolicy' in probe_data)
+        self.assertTrue('replicationpolicy' in probe_data)
+
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_safeguarded_snapshot_policy(self, mock_svc_authorize,
+                                                svc_obj_info_mock,
+                                                svc_run_command_mock):
+        set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volumegroup',
+            'snapshotpolicy': 'ss_policy2',
+            'safeguarded': True,
+            'ignoreuserfcmaps': 'yes',
+            'state': 'present',
+        })
+        data = {
+            "id": "8",
+            "name": "test_volumegroup",
+            "volume_count": "0",
+            "backup_status": "empty",
+            "last_backup_time": "",
+            "owner_id": "",
+            "owner_name": "",
+            "safeguarded_policy_id": "",
+            "safeguarded_policy_name": "",
+            "safeguarded_policy_start_time": "",
+            "snapshot_policy_name": "ss_policy1",
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
+        }
+
+        vg = IBMSVCVG()
+        probe_data = vg.vg_probe(data)
+        self.assertTrue('safeguarded' in probe_data)
+        self.assertTrue('snapshotpolicy' in probe_data)
+        self.assertTrue('ignoreuserfcmaps' in probe_data)
 
     @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
            'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
@@ -846,6 +915,7 @@ class TestIBMSVCvdisk(unittest.TestCase):
             'password': 'password',
             'name': 'test_volumegroup',
             'nosnapshotpolicy': True,
+            'noreplicationpolicy': True,
             'state': 'present',
         })
         data = {
@@ -860,12 +930,16 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "ss_policy2",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no",
+            "replication_policy_name": "rp0"
         }
 
         vg = IBMSVCVG()
         probe_data = vg.vg_probe(data)
         self.assertTrue('nosnapshotpolicy' in probe_data)
+        self.assertTrue('noreplicationpolicy' in probe_data)
 
     @patch('ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.'
            'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
@@ -897,7 +971,9 @@ class TestIBMSVCvdisk(unittest.TestCase):
             "safeguarded_policy_name": "",
             "safeguarded_policy_start_time": "",
             "snapshot_policy_name": "ss_policy2",
-            "snapshot_policy_suspended": "no"
+            "snapshot_policy_suspended": "no",
+            "ignore_user_flash_copy_maps": "no",
+            "snapshot_policy_safeguarded": "no"
         }
 
         vg = IBMSVCVG()


### PR DESCRIPTION
##### SUMMARY
Q3 2022 Addition -

Support added for managing new SV feature "Policy Based Replication" through Ansible. This includes following modules:

- Support added for management of replication policy

- Support added for replication pool linking

- Support added to switch the replication direction

- Support added to export an existing system certificate

- Support added to transfer the SSL certificate from the remote system and add it to the trust store (truststore management)

Support added for management of safeguarded snapshots (SG2.0)
Support added for management of provisioning policies


##### COMPONENT NAME
**New modules:**
ibm_sv_manage_replication_policy
ibm_sv_switch_replication_direction
ibm_sv_manage_SSL_certificate
ibm_sv_manage_truststore_for_replication
**Modified modules:**
ibm_sv_manage_snapshot
ibm_svc_manage_volumegroup
ibm_svc_mdiskgrp


