### PR TITLE
Iterate over lsdrive output to get detail information from the drive

### DIFF
--- a/plugins/modules/ibm_svc_info.py
+++ b/plugins/modules/ibm_svc_info.py
@@ -618,6 +618,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.spectrum_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec, get_logger
 from ansible.module_utils._text import to_native
 
+import time
+
 
 class IBMSVCGatherInfo(object):
     def __init__(self):
@@ -739,6 +741,15 @@ class IBMSVCGatherInfo(object):
                 output[op_key] = self.restapi.svc_obj_info(cmd=cmd,
                                                            cmdopts=None,
                                                            cmdargs=cmdargs)
+                if cmd == "lsdrive":
+                    drive = []
+                    for d in output[op_key]:
+                        self.log.info("log iteration %s", d["id"])
+                        cmdargs = [d["id"]]
+                        time.sleep(0.08)
+                        d.update(self.restapi.svc_obj_info(cmd=cmd,
+                                                               cmdopts=None,
+                                                               cmdargs=cmdargs))            
             self.log.info('Successfully listed %d %s info '
                           'from cluster %s', len(subset), subset,
                           self.module.params['clustername'])


### PR DESCRIPTION
SUMMARY
Add detail information to Drives vial lsdrive detail api call.

ISSUE TYPE
Feature Idea
COMPONENT NAME
ibm_svc_info.py

ADDITIONAL INFORMATION
Currently there is no way to get the Firmware Information for each drive.

Overview information for drives contains

    - auto_manage: 
      capacity: 
      drive_class_id:
      enclosure_id: 
      error_sequence_number: ''
      id: 
      mdisk_id: 
      mdisk_name:
      member_id: 
      node_id: 
      node_name: 
      slot_id: 
      status: 
      tech_type:
      use: 
detail call includes

    - FPGA_level: ''
      FRU_identity: 
      FRU_part_number: 
      RPM: ''
      UID: 
      auto_manage: 
      block_size: ''
      capacity: 
      compressed: ''
      date_of_manufacture: ''
      drive_class_id: ''
      effective_used_capacity: ''
      enclosure_id: ''
      error_sequence_number: ''
      firmware_level: 
      id: ''
      interface_speed: 
      mdisk_id: ''
      mdisk_name: 
      member_id: ''
      node_id: ''
      node_name: ''
      physical_capacity: 
      physical_used_capacity: ''
      port_1_status: 
      port_2_status: 
      product_id: ''
      protection_enabled: ''
      quorum_id: ''
      replacement_date: ''
      slot_id: ''
      status: 
      tech_type: 
      transport_protocol: 
      use: member
      vendor_id: 
      write_endurance_usage_rate: ''
      write_endurance_used: ''